### PR TITLE
fix(cicd): pin npm@11 for oidc publish to keep node compat

### DIFF
--- a/.github/workflows/.publish-npm.yml
+++ b/.github/workflows/.publish-npm.yml
@@ -49,7 +49,7 @@ jobs:
           MIN_VERSION="11.5.1"
           if [ "$(printf '%s\n' "$MIN_VERSION" "$NPM_VERSION" | sort -V | head -n1)" != "$MIN_VERSION" ]; then
             echo "npm $NPM_VERSION < $MIN_VERSION, will upgrade npm now to support oidc..."
-            npm install -g npm@latest
+            npm install -g npm@11 # pin to v11: satisfies the oidc MIN_VERSION yet stays compatible with the node pinned in .nvmrc (npm@12 requires node >=22.22.2)
           else
             echo "npm $NPM_VERSION >= $MIN_VERSION, ready to use!"
           fi


### PR DESCRIPTION
fix(cicd): pin npm@11 for oidc publish to keep node compat

- npm@latest rolled to npm@12 which requires node >=22.22.2
- .nvmrc pins node v22.21.0, so npm@12 fails EBADENGINE in the publish job
- pin the oidc upgrade to npm@11 (satisfies MIN_VERSION 11.5.1, node-22.21 compatible)

---
🐢🌊 surfed in by seaturtle[bot]