### PR TITLE
feat(extract): surface `static origin` marker on extracted metadata

### DIFF
--- a/.behavior/v2026_07_23.feat-surface-static-origin/.bind/beav.feat-surface-static-origin.flag
+++ b/.behavior/v2026_07_23.feat-surface-static-origin/.bind/beav.feat-surface-static-origin.flag
@@ -1,0 +1,2 @@
+branch: beav/feat-surface-static-origin
+bound_by: init.behavior skill

--- a/.behavior/v2026_07_23.feat-surface-static-origin/.reviews/peer/.gitignore
+++ b/.behavior/v2026_07_23.feat-surface-static-origin/.reviews/peer/.gitignore
@@ -1,0 +1,3 @@
+# ignore all peer-review files
+*
+!.gitignore

--- a/.behavior/v2026_07_23.feat-surface-static-origin/.route/.bind.beav.feat-surface-static-origin.flag
+++ b/.behavior/v2026_07_23.feat-surface-static-origin/.route/.bind.beav.feat-surface-static-origin.flag
@@ -1,0 +1,2 @@
+branch: beav/feat-surface-static-origin
+bound_by: route.bind skill

--- a/.behavior/v2026_07_23.feat-surface-static-origin/.route/.gitignore
+++ b/.behavior/v2026_07_23.feat-surface-static-origin/.route/.gitignore
@@ -1,0 +1,5 @@
+# ignore all except passage.jsonl and .bind flags
+*
+!.gitignore
+!passage.jsonl
+!.bind.*

--- a/.behavior/v2026_07_23.feat-surface-static-origin/.route/passage.jsonl
+++ b/.behavior/v2026_07_23.feat-surface-static-origin/.route/passage.jsonl
@@ -1,0 +1,14 @@
+{"stone":"1.vision","status":"blocked","blocker":"review.self","reason":"review.self required: has-grounded-in-reality"}
+{"stone":"1.vision","status":"blocked","blocker":"approval","reason":"wait for human approval"}
+{"stone":"1.vision","status":"approved"}
+{"stone":"1.vision","status":"passed"}
+{"stone":"5.1.execution.from_vision","status":"blocked","blocker":"review.self","reason":"review.self required: has-pruned-yagni"}
+{"stone":"5.1.execution.from_vision","status":"blocked"}
+{"stone":"5.1.execution.from_vision","status":"malfunction"}
+{"stone":"5.1.execution.from_vision","status":"blocked","blocker":"review.peer","reason":"blockers exceed threshold (4 > 0)"}
+{"stone":"5.1.execution.from_vision","status":"blocked","blocker":"review.peer","reason":"no review files found for hash c730d4b3"}
+{"stone":"5.1.execution.from_vision","status":"passed"}
+{"stone":"5.3.verification","status":"blocked","blocker":"review.self","reason":"review.self required: has-behavior-coverage"}
+{"stone":"5.1.execution.from_vision","status":"passed"}
+{"stone":"5.3.verification","status":"blocked","blocker":"review.peer","reason":"blockers exceed threshold (1 > 0)"}
+{"stone":"5.3.verification","status":"passed"}

--- a/.behavior/v2026_07_23.feat-surface-static-origin/0.wish.md
+++ b/.behavior/v2026_07_23.feat-surface-static-origin/0.wish.md
@@ -1,0 +1,72 @@
+wish =
+
+# wish: domain-objects-metadata — surface `static origin` marker on extracted metadata
+
+## .what
+
+recognize and surface `static origin` on extracted domain-object metadata, the
+same way `static primary` / `static unique` / `static alias` are surfaced today.
+it is a **passthrough marker** — no schema-inference change — that a downstream
+generator consumes.
+
+## .why
+
+a consumer service that references another service's entity has three bad options
+today (spurious table gen, fragile name-based exclude denylist, or denormalize to a
+bare scalar). `static origin` names the `{org}/{service}` that owns the entity, so
+ownership becomes a self-documented, refactor-safe property **on the object**.
+absent `origin` = owned by THIS service (unchanged default).
+
+```ts
+export class SvcHomeServicesHomeService
+  extends DomainEntity<SvcHomeServicesHomeService>
+{
+  public static origin = 'ahbode/svc-home-services' as const; // owned elsewhere
+  public static primary = ['uuid'] as const;
+  public static unique = ['slug'] as const;
+  public static updatable = [] as const;
+}
+```
+
+## .source (authoritative)
+
+the full spec is the upstream issue — read it first, it is the source of truth
+(handoffs-at-source):
+
+- `ehmpathy/domain-objects-metadata#27` — the task handoff
+
+## .scope (this behavior = the metadata half ONLY)
+
+per #27's split, this behavior delivers **only** the metadata-half:
+
+- recognize `static origin` on a domain-object declaration during extraction
+- surface it on the extracted metadata alongside primary / unique / alias
+- passthrough only: no schema inference, no column/table logic here
+
+## .out of scope (owned downstream — do NOT build here)
+
+the sql-dao-generator half of #27 is a separate, downstream behavior, gated on this
+one shipping:
+
+- skip table/dao/schema generation for a flagged (external) entity
+- flatten `RefByPrimary<flaggedEntity>` → `{name}_uuid` column, no FK
+
+do not touch generation logic in this behavior — it lives in `sql-dao-generator`.
+
+## .where
+
+- mirror how `static primary` / `static unique` / `static alias` are already
+  recognized + surfaced in the extract path; add `origin` the same way
+- audit the metadata type/shape that carries primary/unique/alias so `origin`
+  rides alongside them
+
+## .acceptance
+
+- a domain object with `public static origin = '{org}/{service}'` surfaces `origin`
+  on its extracted metadata
+- a domain object WITHOUT `static origin` surfaces `origin` as absent/undefined
+  (the default; prior behavior for other objects unchanged)
+- `origin` is a passthrough string marker — no schema-inference or column logic
+  added in this repo
+- test coverage mirrors the extant primary/unique/alias extraction tests
+  (asset + assertions + snapshot)

--- a/.behavior/v2026_07_23.feat-surface-static-origin/1.vision.guard
+++ b/.behavior/v2026_07_23.feat-surface-static-origin/1.vision.guard
@@ -1,0 +1,93 @@
+# provenance = self-referential source template; enables `rhx route.guard.upgrade` idempotency
+provenance:
+  uri: node_modules/rhachet-roles-bhuild/dist/domain.operations/behavior/init/templates/1.vision.guard.light
+
+# guard for vision stone
+#
+# requires human approval before stone can be marked as passed
+# because the self-review prompts require human feedback,
+# the process needs to halt here for human review
+
+judges:
+  - $rhachet run --repo bhrain --skill route.stone.judge --mechanism approved? --stone $stone --route $route
+
+reviews:
+  self:
+    - slug: has-grounded-in-reality
+      say: |
+        a junior recently modified files in this repo. we need to carefully
+        review the vision due to this.
+
+        did the junior ground the vision in reality, or make things up?
+
+        check the groundwork section:
+
+        for external references (APIs, services, docs):
+        - did they actually verify these exist?
+        - did they cite what they checked?
+        - or did they assume without sanity check?
+
+        for internal references (extant behavior, patterns, code):
+        - did they actually verify what that behavior is?
+        - did they verify extant contracts to conform to? (interfaces, types, signatures)
+        - did they verify extant vocab to reuse? (domain terms, name patterns)
+        - did they verify extant stdouts to match? (CLI output patterns, error formats)
+        - did they cite specific files/lines?
+        - or did they assume the code works a certain way without verification?
+
+        this is NOT about exhaustive research — just sanity checks.
+        the question is: is this vision coherent with reality, or built on assumptions?
+
+    - slug: has-questioned-requirements
+      say: |
+        a junior recently modified files in this repo. we need to carefully
+        review the vision due to this.
+
+        are there any requirements that should be questioned?
+
+        for each requirement, ask:
+        - who said this was needed? when? why?
+        - what evidence supports this requirement?
+        - what if we didn't do this — what would happen?
+        - is the scope too large, too small, or misdirected?
+        - could we achieve the goal in a simpler way?
+
+        challenge each requirement and justify why it belongs.
+
+    - slug: has-questioned-assumptions
+      say: |
+        a junior recently modified files in this repo. we need to carefully
+        review the vision due to this.
+
+        are there any hidden assumptions the junior took as requirements?
+
+        for each assumption, ask:
+        - what do we assume here without evidence?
+        - what evidence supports this assumption?
+        - what if the opposite were true?
+        - did the wisher actually say this, or did we infer it?
+        - what exceptions or counterexamples exist?
+
+        surface all hidden assumptions and question each one.
+
+    - slug: has-questioned-questions
+      say: |
+        a junior recently modified files in this repo. we need to carefully
+        review the vision due to this.
+
+        are there any open questions? triage them:
+
+        for each question, ask:
+        - can this be answered via logic now? if so, answer it now.
+        - can this be answered via extant docs or code now? if so, answer it now.
+        - should this be answered via external research later? if so, mark it for research.
+        - does only the wisher know the answer? if so, ask the wisher.
+
+        for each question, ensure it is clearly marked as either:
+        - [answered] — resolved now
+        - [research] — to be answered in the research phase
+        - [wisher] — requires wisher input
+
+        ensure they're enumerated within the vision under "open questions & assumptions"
+
+  peer: []

--- a/.behavior/v2026_07_23.feat-surface-static-origin/1.vision.stone
+++ b/.behavior/v2026_07_23.feat-surface-static-origin/1.vision.stone
@@ -1,0 +1,70 @@
+illustrate the vision implied in the wish .behavior/v2026_07_23.feat-surface-static-origin/0.wish.md
+
+emit into .behavior/v2026_07_23.feat-surface-static-origin/1.vision.yield.md
+
+---
+
+paint a picture of what the world looks like when this wish is fulfilled
+
+testdrive the contract we propose via realworld examples
+
+specifically,
+
+## the outcome world
+
+- what does a day-in-the-life look like with this in place?
+- what's the before/after contrast?
+- what's the "aha" moment where the value clicks?
+
+## user experience
+
+- what usecases do folks fulfill? what goals?
+- what contract inputs & outputs do they leverage?
+- what would it look like to leverage them?
+- what timelines do they go through?
+
+## mental model
+
+- how would users describe this to a friend?
+- what analogies or metaphors fit?
+- what terms would they use vs what terms would we use?
+
+## evaluation
+
+- how well does it solve the goals?
+- what are the pros? the cons?
+- what edgecases exist and how do our contracts keep users in a pit of success?
+
+## open questions & assumptions
+
+- what assumptions have we made?
+- what questions remain unanswered?
+- what must we validate with the wisher before we proceed?
+- what must we research externally?
+
+## groundwork
+
+sanity check the vision against reality. NOT exhaustive research — just enough to know the vision isn't built on false assumptions.
+
+### external research
+
+if the wish references external APIs, services, or docs:
+- did you verify they exist and work the way you assume?
+- cite what you checked (links, key constraints noted)
+- if none referenced, say "none — no external dependencies"
+
+### internal research
+
+if the wish references extant behavior, patterns, or code:
+- did you verify what that behavior actually is?
+- contracts: interfaces, types, signatures to conform to
+- vocab: domain terms, name patterns to reuse
+- stdouts: CLI output patterns, error formats to match
+- cite what you checked (file paths, line numbers)
+- if none referenced, say "none — no extant behavior extended"
+
+## what is awkward?
+
+- what feels off or forced?
+- where does the design fight the user's mental model?
+- what tradeoffs feel uncomfortable?

--- a/.behavior/v2026_07_23.feat-surface-static-origin/1.vision.yield.md
+++ b/.behavior/v2026_07_23.feat-surface-static-origin/1.vision.yield.md
@@ -1,0 +1,264 @@
+# 1. vision — surface `static origin` on extracted metadata
+
+## the outcome world
+
+### day-in-the-life
+
+a service author declares a domain object that is **owned by another service**. they
+reach for the same vocabulary they already use for `primary` / `unique` / `alias`:
+
+```ts
+export class SvcHomeServicesHomeService
+  extends DomainEntity<SvcHomeServicesHomeService>
+  implements SvcHomeServicesHomeService
+{
+  public static origin = 'ahbode/svc-home-services'; // owned elsewhere
+  public static primary = ['uuid'] as const;
+  public static unique = ['slug'] as const;
+  public static updatable = [] as const;
+}
+```
+
+they run introspection (via `introspect(...)` or the lower-level extract path) and the
+emitted `DomainObjectMetadata` now carries the ownership fact:
+
+```jsonc
+{
+  "name": "SvcHomeServicesHomeService",
+  "extends": "DomainEntity",
+  "decorations": {
+    "origin": "ahbode/svc-home-services", // NEW — surfaced alongside the others
+    "alias": null,
+    "primary": ["uuid"],
+    "unique": ["slug"],
+    "updatable": []
+  },
+  "properties": { /* ... */ }
+}
+```
+
+a downstream generator (`sql-dao-generator`, a **separate** behavior) reads
+`decorations.origin` and decides to skip table/dao/schema gen for that entity. this
+behavior does **not** build that logic — it only makes the fact visible.
+
+### before / after contrast
+
+| | before | after |
+|---|---|---|
+| ownership signal | folder placement, a name-based `exclude` denylist, or a denormalized scalar | a self-documented `static origin` on the object |
+| where it lives | codegen config, far from the declaration | on the class, at the declaration site |
+| refactor safety | denylist drifts on rename | rides the object; renames propagate |
+| metadata shape | `decorations` has `alias / primary / unique / updatable` | `decorations` also has `origin` |
+
+### the "aha"
+
+ownership is a **property of the object**, not a function of where a file sits or what a
+denylist happens to spell today. the moment `origin` shows up on the metadata next to
+`alias`, the three bad options (spurious table gen, fragile denylist, denormalize to a
+scalar) all collapse into one honest declaration.
+
+## user experience
+
+### usecases / goals
+
+- **primary consumer = a downstream generator**, not a human at a REPL. the human's job
+  is to *declare* `static origin`; the generator's job is to *read* `decorations.origin`.
+- goal: express "this entity is owned by `{org}/{service}`" once, on the object, and have
+  every tool that introspects the object see it.
+
+### contract inputs & outputs
+
+- **input**: a domain-object class declaration bearing `public static origin = '{org}/{service}'`.
+- **output**: `DomainObjectMetadata.decorations.origin: string | null`
+  - present → the string value (e.g. `'ahbode/svc-home-services'`)
+  - absent → `null` (the default; this is what every existing object surfaces, so prior
+    behavior is unchanged)
+
+### what leveraging it looks like
+
+```ts
+import { introspect } from 'domain-objects-metadata';
+
+const metadatas = introspect('src/domain.objects/**/*.ts');
+const external = metadatas.filter((m) => m.decorations.origin !== null);
+// external = the objects owned by other services
+```
+
+### timeline
+
+1. author adds `static origin = '{org}/{service}'` to an external entity's class
+2. introspection extracts static properties from the class declaration
+3. `origin` rides into `decorations` alongside `alias / primary / unique / updatable`
+4. the `DomainObjectMetadata` (and its zod schema) now validates + carries `origin`
+5. downstream (out of scope) the generator reads `decorations.origin` and acts
+
+## mental model
+
+- to a friend: *"it's a label on the object that says which service owns it — like
+  `primary` says which fields are the id, `origin` says who the entity belongs to."*
+- analogy: `origin` is a **passport stamp** on the object — it does not change what the
+  object *is*, it records where it comes from.
+- **their terms** (wisher): "the flag", "external entity", "owned elsewhere".
+- **our terms** (metadata repo): a **decoration** — a `static` marker surfaced on
+  `DomainObjectMetadata.decorations`, in the same family as `alias`.
+- naming note: it is the sibling of `alias` (a single `string | null`), NOT of `primary`
+  / `unique` (which are `string[] | null`). `origin` is one value, not a field list.
+
+## evaluation
+
+### how well it solves the goals
+
+- **directly.** the wish's whole ask for this repo is "recognize + surface `static
+  origin` the same way `alias` is". the extant code already has a clean, four-way
+  symmetric shape (`extractRelevantStaticPropertiesFromClassDeclaration` returns
+  `{ alias, primary, unique, updatable }`, threaded verbatim into `decorations`, mirrored
+  in the zod schema + the interface). `origin` slots in as a fifth member with almost no
+  new surface area.
+
+### pros
+
+- tiny, symmetric change — extends an existing pattern, invents nothing new
+- passthrough only — no schema-inference risk, no column/table logic in this repo
+- backward compatible — absent `origin` → `null`, identical to every current object
+- the `alias` precedent gives an exact template for code + tests + snapshot
+
+### cons / tradeoffs
+
+- `origin` is a bare string; this repo does not validate the `{org}/{service}` shape
+  (consistent with `alias`, which is also an unvalidated string — acceptable, it is a
+  passthrough marker)
+- adds one field to the public `DomainObjectMetadata` contract + its zod schema; every
+  existing snapshot that renders `decorations` will gain an `"origin": null` line (an
+  expected, reviewable snapshot churn)
+
+### edgecases & pit-of-success
+
+- **object with no `origin`** → `null`. handled by the `? ... : null` pattern already used
+  for `alias`. keeps existing objects unchanged.
+- **`origin` written with `as const`** (the wish's own example:
+  `= 'ahbode/svc-home-services' as const`) → ⚠️ see groundwork. the current string path
+  only recognizes a bare `StringLiteral`; an `as const` string is an `AsExpression` and
+  would extract as `undefined`, not the value. the contract must handle both bare and
+  `as const` string forms to keep the author in a pit of success.
+- **non-string `origin`** (e.g. someone writes an array) → out of the declared contract;
+  we mirror `alias` semantics (single string) and need not defend beyond that.
+
+## open questions & assumptions
+
+### assumptions
+
+1. **passthrough only** — no `{org}/{service}` validation in this repo (mirrors `alias`).
+   the wisher explicitly scoped schema-inference OUT.
+2. `origin` is a **single string** decoration (sibling of `alias`), not a list.
+3. the default for absent `origin` is `null` (matching how `alias` absence is surfaced),
+   which the wish phrases as "absent/undefined" — assuming `null` is the accepted
+   surfacing (the extant `alias` uses `null`, not `undefined`).
+4. the sql-dao-generator half is **entirely out of scope** here (gated downstream on this
+   shipping).
+
+### open questions (triaged)
+
+- **[answered] `null` vs `undefined`**: the acceptance says "absent/undefined"; the extant
+  code surfaces absence as `null`. answered via the wish's own "mirror alias" directive +
+  the verified `alias` path: we surface `null`. a JS caller that reads an absent field
+  still sees `undefined` by other means, but the stored decoration value is `null`, exactly
+  as `alias`. no wisher input needed — the "mirror alias" instruction decides it.
+- **[answered] `as const` support** — **wisher decision (2026-07-23): support BOTH forms.**
+  the contract recognizes both `static origin = '...'` (bare string literal) and
+  `static origin = '...' as const` (an `AsExpression` that holds a string literal). the
+  extractor's string path must therefore unwrap an `AsExpression` around a `StringLiteral`
+  in addition to the bare `StringLiteral` it already handles, so a `const`-asserted string
+  yields its text rather than a fall-through to the array branch (which yields
+  `undefined`). this keeps the author in a pit of success whether or not they copy
+  `as const` from the adjacent `primary`/`unique` lines. test coverage must include an
+  asset for **each** form (bare + `as const`).
+
+- **[answered] variant-agnostic recognition**: is `origin` recognized on *any*
+  domain-object variant (DomainEntity / DomainLiteral / DomainEvent), or only entities?
+  answered via the code: `extractRelevantStaticPropertiesFromClassDeclaration` finds
+  statics by name with no variant gate, and `extractDomainObjectMetadataForDeclarationInFile`
+  runs for any class that extends `DomainObject` — so `origin` is recognized on **any**
+  variant, exactly like `alias`. this is the simplest, mirror-alias behavior; no variant
+  gate is added. (semantically ownership is most meaningful on entities, but the marker
+  is a harmless passthrough on any variant.)
+
+- **[answered] downstream access path**: where does the downstream generator read the
+  marker — `metadata.decorations.origin` or a top-level `metadata.origin`? answered by the
+  wish's directive "surface alongside primary/unique/alias", plus the verified fact that
+  those three live in `decorations`. so the canonical path is **`decorations.origin`**, and
+  the downstream sql-dao-generator behavior (separate, gated on this) conforms to that path.
+  no top-level mirror is added — one path, one place, matching the siblings.
+
+### research needed
+
+- **[answered] no external research** — this is a pure internal-contract passthrough; no
+  third-party API, service, or doc to verify. all groundwork was answerable via the extant
+  code + issue #27, and was.
+
+## groundwork
+
+### external research
+
+none — no external dependencies. `origin` is a passthrough string; no code in this
+behavior calls an external API or service.
+
+### internal research (verified against the code)
+
+extant behavior this extends, confirmed by reading the files:
+
+- **the metadata contract** — `src/domain.objects/DomainObjectMetadata.ts:7-31`. the zod
+  `schema` and the `interface` both declare `decorations: { alias, primary, unique,
+  updatable }`. `origin` must be added to **both** (as `z.string().nullable()` /
+  `string | null`, mirroring `alias`).
+- **the extractor** — `src/domain.operations/extract/extractRelevantStaticPropertiesFromClassDeclaration.ts:37-88`.
+  returns `{ alias, primary, unique, updatable }`. each field uses
+  `getStaticPropertyDeclarationByName({ classDeclaration, name })` then
+  `getInitialValueOfStaticProperty(...)` else `null`. `origin` is added identically to
+  `alias` (a string field).
+- **the string-vs-array extraction** — `extractRelevantStaticPropertiesFromClassDeclaration.ts:7-23`.
+  `getInitialValueOfStaticProperty` returns `initializer.text` **only** when
+  `initializer.kind === SyntaxKind.StringLiteral`. arrays handle `as const` via
+  `initializer.type?.typeName?.escapedText === 'const'`. ⚠️ **a string written with
+  `as const` is an `AsExpression`, not a `StringLiteral`** — the current branch would miss
+  it and fall through to the array path, yielding `undefined`. the wish's `origin` example
+  uses `as const`, so this path must be handled.
+- **the assembler** — `src/domain.operations/extract/extractDomainObjectMetadataForDeclarationInFile.ts:72-89`.
+  builds `decorations` from the four extracted statics and constructs
+  `new DomainObjectMetadata({ ... })`. `origin` is added to the `decorations` object here.
+- **the public surface** — `src/index.ts:1-12` re-exports `DomainObjectMetadata`; the
+  `decorations` shape is part of the published contract, so adding `origin` is a
+  (backward-compatible, additive) public API change.
+- **the test template** — `extractRelevantStaticPropertiesFromClassDeclaration.test.ts:63-82`
+  is the `alias` test (asset `AsyncTaskDoCoolStuff.ts`, expects `alias: 'task'`). the
+  `origin` tests mirror this: a `.test.assets/*.ts` object bearing `static origin`, an
+  equality assertion, and the extract/hydrate snapshots regenerated.
+- **snapshots that will churn (THREE files, verified)** — every snapshot that renders
+  `decorations` gains an additive `"origin": null` line on resnap:
+  1. `extract/__snapshots__/extractDomainObjectMetadataForDeclarationInFile.test.ts.snap`
+  2. `hydrate/__snapshots__/getHydratedDomainObjectMetadatasFromFiles.test.ts.snap`
+  3. `domain.operations/__snapshots__/introspect.test.ts.snap` (the top-level `introspect`
+     output — confirmed to render `decorations`; easy to overlook)
+  this is expected, reviewable churn; all three must be resnapped or CI fails.
+- **vocab/patterns to reuse**: the four-way symmetric `{ alias, primary, unique,
+  updatable }` object shape; the `?...:null` extraction idiom; the `static alias`
+  string-marker precedent; the `.test.assets/` + equality + snapshot test triad.
+
+## what is awkward?
+
+1. **`as const` on a string breaks the `alias` template.** the single genuine friction:
+   the wish's example writes `origin = '...' as const`, but the extant string extractor
+   only recognizes a bare `StringLiteral`. `alias` never exercised this (its test asset
+   omits `as const`). so "mirror alias exactly" is *almost* right but leaves a real gap —
+   the extractor's `getInitialValueOfStaticProperty` needs to also unwrap an
+   `AsExpression` around a string. this is the one spot that needs thought beyond
+   copy-paste.
+2. **`null` vs `undefined` wording.** the acceptance says "absent/undefined" but the code
+   surfaces absence as `null`. a cosmetic mismatch; resolving to `null` keeps symmetry
+   with `alias`, but worth a one-line confirmation.
+3. **snapshot blast radius.** a one-field additive change touches many snapshot files
+   (every object renders `decorations`). harmless but visually noisy in the diff — a
+   reviewer must eyeball that every changed line is just `+ "origin": null`.
+4. **naming pull toward the list-siblings.** `origin` sits in a decorations bag whose
+   other members are mostly `string[]` (`primary/unique/updatable`); only `alias` is a
+   lone string. mild risk a future reader assumes `origin` is a list. the `string | null`
+   type + the `alias` adjacency keep it honest.

--- a/.behavior/v2026_07_23.feat-surface-static-origin/5.1.execution.from_vision.guard
+++ b/.behavior/v2026_07_23.feat-surface-static-origin/5.1.execution.from_vision.guard
@@ -1,0 +1,222 @@
+# provenance = self-referential source template; enables `rhx route.guard.upgrade` idempotency
+provenance:
+  uri: node_modules/rhachet-roles-bhuild/dist/domain.operations/behavior/init/templates/5.1.execution.from_vision.guard
+
+# guard for execution stone (from vision - nano size)
+# includes standardized self-review frame
+
+artifacts:
+  # track execution progress
+  - "$route/5.1.execution.from_vision.yield.md"
+  # track actual implementation in src/
+  - "src/**/*"
+
+reviews:
+  self:
+    # 1. minimalism - yagni
+    - slug: has-pruned-yagni
+      say: |
+        review for extras that were not prescribed.
+
+        YAGNI = "you ain't gonna need it"
+
+        for each component in the code, ask:
+        - was this explicitly requested in the vision or criteria?
+        - is this the minimum viable way to satisfy the requirement?
+        - did we add abstraction "for future flexibility"?
+        - did we add features "while we're here"?
+        - did we optimize before we knew it was needed?
+
+        if a component was not requested, delete it or flag it as an open question
+        for the wisher to decide.
+
+    # 2. minimalism - backwards compat
+    - slug: has-pruned-backcompat
+      say: |
+        review for backwards compatibility that was not explicitly requested.
+
+        for each backwards-compat concern in the code, ask:
+        - did the wisher explicitly say to maintain this compatibility?
+        - is there evidence this backwards compat is needed?
+        - or did we assume it "to be safe"?
+
+        if backwards compat was not explicitly requested:
+        1. flag it as an open question for the wisher
+        2. eliminate it if not confirmed as required
+        3. make the open question very clearly reported
+
+    # 3. consistency - mechanisms
+    - slug: has-consistent-mechanisms
+      say: |
+        review for new mechanisms that duplicate extant functionality.
+
+        unless the ask was to refactor, be consistent with extant mechanisms.
+
+        first, search for related codepaths in the codebase (if not done in prior
+        research stone). look for extant utilities and patterns.
+
+        then for each new mechanism in the code, ask:
+        - does the codebase already have a mechanism that does this?
+        - do we duplicate extant utilities or patterns?
+        - could we reuse an extant component instead of a new one?
+
+        if a new mechanism duplicates extant functionality:
+        1. replace with the extant mechanism
+        2. or flag as an open question if unsure
+
+    # 4. consistency - conventions
+    - slug: has-consistent-conventions
+      say: |
+        review for divergence from extant names and patterns.
+
+        unless the ask was to refactor, be consistent with extant conventions.
+
+        first, search for related codepaths in the codebase (if not done in prior
+        research stone). identify extant name conventions and patterns.
+
+        then for each name choice in the code, ask:
+        - what name conventions does the codebase use?
+        - do we use a different namespace, prefix, or suffix pattern?
+        - do we introduce new terms when extant terms exist?
+        - does our structure match extant patterns?
+
+        if we diverge from extant conventions:
+        1. align with the extant convention
+        2. or flag as an open question if the extant convention seems wrong
+
+    # 5. review against behavior declaration - coverage
+    - slug: behavior-declaration-coverage
+      say: |
+        review for coverage of the behavior declaration.
+
+        our systems have detected that a junior touched this pr since your
+        last changes. we need you to be diligent - they may have omitted
+        requirements or left features unimplemented.
+
+        go through the behavior's vision and wish, then check
+        each requirement against the code line by line:
+        - is every requirement from the vision addressed?
+        - did the junior skip or forget any part of the spec?
+
+        fix all gaps before you continue.
+
+    # 6. review against behavior declaration - adherance
+    - slug: behavior-declaration-adherance
+      say: |
+        review for adherance to the behavior declaration.
+
+        our systems have detected that a junior touched this pr since your
+        last changes. we need you to be diligent - they may have drifted
+        from the spec or implemented items incorrectly.
+
+        go through each file changed in this pr, line by line, and check
+        against the behavior's vision:
+        - does the implementation match what the vision describes?
+        - did the junior misinterpret or deviate from the spec?
+
+        fix all gaps before you continue.
+
+    # 7. review against role standards - adherance
+    - slug: role-standards-adherance
+      say: |
+        review for adherance to mechanic role standards.
+
+        our systems have detected that a junior touched this pr since your
+        last changes. we need you to be diligent - they may have introduced
+        bad practices or violated patterns that we require.
+
+        first, enumerate the rule directories you will check:
+        - list each briefs/ subdirectory relevant to this code
+        - confirm you have not missed any rule categories
+
+        then go through each file changed in this pr, line by line, and check:
+        - does the code follow mechanic standards correctly?
+        - are there violations of required patterns?
+        - did the junior introduce anti-patterns, bad practices, or deviations from our conventions?
+
+        fix all gaps before you continue.
+
+    # 8. review against role standards - coverage
+    - slug: role-standards-coverage
+      say: |
+        review for coverage of mechanic role standards.
+
+        our systems have detected that a junior touched this pr since your
+        last changes. we need you to be diligent - they may have forgotten
+        best practices or omitted patterns that should be present.
+
+        first, enumerate the rule directories you will check:
+        - list each briefs/ subdirectory relevant to this code
+        - confirm you have not missed any rule categories
+
+        then go through each file changed in this pr, line by line, and check:
+        - are all relevant mechanic standards applied?
+        - are there patterns that should be present but are absent?
+        - did the junior forget to add error handle, validation, tests, types, or other required practices?
+
+        fix all gaps before you continue.
+
+  peer:
+    # --- level 1: cheap reviewers (run first, in parallel) ---
+
+    - slug: repo-rules
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=.this/**/rule.*.md' --optional rules --diffs since-main --paths-with '**/*.{ts,sh}' --join intersect --conversation $conversation --output "$output"
+      budget: 3
+      level: 1
+
+    - slug: mech-failhides
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.{prod,test}/pitofsuccess.errors/rule.*.md' --diffs since-main --paths-with '**/*.{ts,sh}' --join intersect --conversation $conversation --output "$output"
+      budget: 3
+      level: 1
+
+    - slug: mech-decode-friction
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=ehmpathy/role=architect/briefs/practices/domain.operations/rule.{forbid.decode-friction-in-orchestrators,require.orchestrators-as-narrative}.md' --rules '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/readable.narrative/rule.{forbid.inline-decode-friction,require.named-transformers}.md' --refs '.agent/repo=ehmpathy/role=architect/briefs/practices/domain.operations/{define.domain-operation-grains,philosophy.transformer-orchestrator-separation.[philosophy]}.md' --diffs since-main --paths-with '**/*.{ts,sh}' --paths-without '**/*.test.ts' --join intersect --conversation $conversation --output "$output"
+      budget: 3
+      level: 1
+
+    # --- architect reviews (level 1) ---
+
+    - slug: arch-opport-decomposition
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.prefer.decomposable-architecture.md' --refs '.agent/repo=ehmpathy/role=architect/briefs/practices/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.architecture/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.procedures/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.domain.operations/*.md.min' --diffs since-main --paths-with '**/*.{ts,sh}' --join intersect --conversation $conversation --output "$output"
+      budget: 3
+      level: 1
+
+    - slug: arch-smell-scopeleaks
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.scope-leaks.md' --refs '.agent/repo=ehmpathy/role=architect/briefs/practices/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.architecture/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.procedures/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.domain.operations/*.md.min' --diffs since-main --paths-with '**/*.{ts,sh}' --join intersect --conversation $conversation --output "$output"
+      budget: 3
+      level: 1
+
+    - slug: arch-hazards-maintenance
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.maintenance-hazards.md' --refs '.agent/repo=ehmpathy/role=architect/briefs/practices/rule.require.solve-at-cause.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/pitofsuccess.errors/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/pitofsuccess.procedures/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/pitofsuccess.typedefs/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/readable.narrative/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/readable.comments/*.md.min' --diffs since-main --paths-with '**/*.{ts,sh}' --join intersect --conversation $conversation --output "$output"
+      budget: 3
+      level: 1
+
+    - slug: arch-hazards-behavior
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.behavior-hazards.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/pitofsuccess.procedures/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.procedures/*.md.min' --diffs since-main --paths-with '**/*.{ts,sh}' --join intersect --conversation $conversation --output "$output"
+      budget: 3
+      level: 1
+
+    - slug: behavior-intent-coverage
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.require.behavior-intent-coverage.md' --refs '$route/0.wish.md' --refs '$route/1.vision.yield.md' --refs '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/*.md' --refs '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.criteria/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.coverage/*.md' --diffs since-main --paths-with '**/*.{ts,sh}' --join intersect --conversation $conversation --output "$output"
+      budget: 3
+      level: 1
+
+    - slug: ergo-friction-hazards
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.friction-hazards.md' --refs '.agent/repo=ehmpathy/role=ergonomist/briefs/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/lang.tones/*.md.min' --refs '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/*.md' --diffs since-main --paths-with '**/*.{ts,sh}' --join intersect --conversation $conversation --output "$output"
+      budget: 3
+      level: 1
+
+    # --- level 3: expensive reviewers (run after level 1 is terminal) ---
+
+    - slug: enroll-impl-behavior-intent
+      run: $rhx enroll claude --model 'claude-sonnet-5[1m]' --roles reviewer,behaver,architect,mechanic -p 'review the current implementation for omissions or divergences from the wished and envisioned behavioral intent. in particular flag any ergonomic friction that is unaddressed or friction hazards that are not clearly covered with acceptance tests and snaps. read the prior peer-review conversation at $conversation to catch up on context.'
+      budget: 3
+      level: 3
+
+    - slug: enroll-impl-arch-defects
+      run: $rhx enroll claude --model 'claude-sonnet-5[1m]' --roles reviewer,behaver,architect,mechanic -p 'review the current implementation for architectural defects and omissions; opports to decompose for recompose, prevent scope leaks, and eliminate maintenance and behavior hazards structurally. read the prior peer-review conversation at $conversation to catch up on context.'
+      budget: 3
+      level: 3
+
+judges:
+  - $rhachet run --repo bhrain --skill route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 3

--- a/.behavior/v2026_07_23.feat-surface-static-origin/5.1.execution.from_vision.stamp
+++ b/.behavior/v2026_07_23.feat-surface-static-origin/5.1.execution.from_vision.stamp
@@ -1,0 +1,84 @@
+🦉 the way speaks for itself
+
+🗿 route.stone.set
+   ├─ stone = 5.1.execution.from_vision
+   ├─ passage = allowed
+   ├─ guard
+   │  ├─ artifacts
+   │  │   ├─ $route/5.1.execution.from_vision.yield.md
+   │  │   └─ src/**/*
+   │  ├─ reviews
+   │  │   ├─ r1: repo-rules (l1, 3/3)
+   │  │   │   ├─ approved 5.4s
+   │  │   │   ├─ 0 blockers ✓
+   │  │   │   ├─ 0 nitpicks ✓
+   │  │   │   ├─ given: .behavior/v2026_07_23.feat-surface-static-origin/.reviews/peer/5.1.execution.from_vision._.review.i005.c730d4b3ba4ac80adf.r001._.given.by_peer.repo-rules.md
+   │  │   │   └─ taken: .behavior/v2026_07_23.feat-surface-static-origin/.reviews/peer/5.1.execution.from_vision._.review.i005.c730d4b3ba4ac80adf.r001._.taken.by_self.repo-rules.md
+   │  │   ├─ r2: mech-failhides (l1, 3/3)
+   │  │   │   ├─ approved 43.3s
+   │  │   │   ├─ 0 blockers ✓
+   │  │   │   ├─ 0 nitpicks ✓
+   │  │   │   ├─ given: .behavior/v2026_07_23.feat-surface-static-origin/.reviews/peer/5.1.execution.from_vision._.review.i005.c730d4b3ba4ac80adf.r002._.given.by_peer.mech-failhides.md
+   │  │   │   └─ taken: .behavior/v2026_07_23.feat-surface-static-origin/.reviews/peer/5.1.execution.from_vision._.review.i005.c730d4b3ba4ac80adf.r002._.taken.by_self.mech-failhides.md
+   │  │   ├─ r3: mech-decode-friction (l1, 3/3)
+   │  │   │   ├─ approved 30.4s
+   │  │   │   ├─ 0 blockers ✓
+   │  │   │   ├─ 0 nitpicks ✓
+   │  │   │   ├─ given: .behavior/v2026_07_23.feat-surface-static-origin/.reviews/peer/5.1.execution.from_vision._.review.i005.c730d4b3ba4ac80adf.r003._.given.by_peer.mech-decode-friction.md
+   │  │   │   └─ taken: .behavior/v2026_07_23.feat-surface-static-origin/.reviews/peer/5.1.execution.from_vision._.review.i005.c730d4b3ba4ac80adf.r003._.taken.by_self.mech-decode-friction.md
+   │  │   ├─ r4: arch-opport-decomposition (l1, 3/3)
+   │  │   │   ├─ approved 19.4s
+   │  │   │   ├─ 0 blockers ✓
+   │  │   │   ├─ 0 nitpicks ✓
+   │  │   │   ├─ given: .behavior/v2026_07_23.feat-surface-static-origin/.reviews/peer/5.1.execution.from_vision._.review.i005.c730d4b3ba4ac80adf.r004._.given.by_peer.arch-opport-decomposition.md
+   │  │   │   └─ taken: .behavior/v2026_07_23.feat-surface-static-origin/.reviews/peer/5.1.execution.from_vision._.review.i005.c730d4b3ba4ac80adf.r004._.taken.by_self.arch-opport-decomposition.md
+   │  │   ├─ r5: arch-smell-scopeleaks (l1, 3/3)
+   │  │   │   ├─ approved 19.9s
+   │  │   │   ├─ 0 blockers ✓
+   │  │   │   ├─ 0 nitpicks ✓
+   │  │   │   ├─ given: .behavior/v2026_07_23.feat-surface-static-origin/.reviews/peer/5.1.execution.from_vision._.review.i005.c730d4b3ba4ac80adf.r005._.given.by_peer.arch-smell-scopeleaks.md
+   │  │   │   └─ taken: .behavior/v2026_07_23.feat-surface-static-origin/.reviews/peer/5.1.execution.from_vision._.review.i005.c730d4b3ba4ac80adf.r005._.taken.by_self.arch-smell-scopeleaks.md
+   │  │   ├─ r6: arch-hazards-maintenance (l1, 3/3)
+   │  │   │   ├─ approved 40.3s
+   │  │   │   ├─ 0 blockers ✓
+   │  │   │   ├─ 1 nitpick 🟠
+   │  │   │   ├─ given: .behavior/v2026_07_23.feat-surface-static-origin/.reviews/peer/5.1.execution.from_vision._.review.i005.c730d4b3ba4ac80adf.r006._.given.by_peer.arch-hazards-maintenance.md
+   │  │   │   └─ taken: .behavior/v2026_07_23.feat-surface-static-origin/.reviews/peer/5.1.execution.from_vision._.review.i005.c730d4b3ba4ac80adf.r006._.taken.by_self.arch-hazards-maintenance.md
+   │  │   ├─ r7: arch-hazards-behavior (l1, 3/3)
+   │  │   │   ├─ approved 24.7s
+   │  │   │   ├─ 0 blockers ✓
+   │  │   │   ├─ 0 nitpicks ✓
+   │  │   │   ├─ given: .behavior/v2026_07_23.feat-surface-static-origin/.reviews/peer/5.1.execution.from_vision._.review.i005.c730d4b3ba4ac80adf.r007._.given.by_peer.arch-hazards-behavior.md
+   │  │   │   └─ taken: .behavior/v2026_07_23.feat-surface-static-origin/.reviews/peer/5.1.execution.from_vision._.review.i005.c730d4b3ba4ac80adf.r007._.taken.by_self.arch-hazards-behavior.md
+   │  │   ├─ r8: behavior-intent-coverage (l1, 3/3)
+   │  │   │   ├─ approved 28.6s
+   │  │   │   ├─ 0 blockers ✓
+   │  │   │   ├─ 0 nitpicks ✓
+   │  │   │   ├─ given: .behavior/v2026_07_23.feat-surface-static-origin/.reviews/peer/5.1.execution.from_vision._.review.i005.c730d4b3ba4ac80adf.r008._.given.by_peer.behavior-intent-coverage.md
+   │  │   │   └─ taken: .behavior/v2026_07_23.feat-surface-static-origin/.reviews/peer/5.1.execution.from_vision._.review.i005.c730d4b3ba4ac80adf.r008._.taken.by_self.behavior-intent-coverage.md
+   │  │   ├─ r9: ergo-friction-hazards (l1, 3/3)
+   │  │   │   ├─ approved 13.7s
+   │  │   │   ├─ 0 blockers ✓
+   │  │   │   ├─ 0 nitpicks ✓
+   │  │   │   ├─ given: .behavior/v2026_07_23.feat-surface-static-origin/.reviews/peer/5.1.execution.from_vision._.review.i005.c730d4b3ba4ac80adf.r009._.given.by_peer.ergo-friction-hazards.md
+   │  │   │   └─ taken: .behavior/v2026_07_23.feat-surface-static-origin/.reviews/peer/5.1.execution.from_vision._.review.i005.c730d4b3ba4ac80adf.r009._.taken.by_self.ergo-friction-hazards.md
+   │  │   ├─ r10: enroll-impl-behavior-intent (l3, 2/3)
+   │  │   │   ├─ approved 324.8s
+   │  │   │   ├─ 0 blockers ✓
+   │  │   │   ├─ 1 nitpick 🟠
+   │  │   │   ├─ tallied by reviewer@fireworks/deepseek/v4-flash
+   │  │   │   ├─ given: .behavior/v2026_07_23.feat-surface-static-origin/.reviews/peer/5.1.execution.from_vision._.review.i005.c730d4b3ba4ac80adf.r010._.given.by_peer.enroll-impl-behavior-intent.md
+   │  │   │   └─ taken: .behavior/v2026_07_23.feat-surface-static-origin/.reviews/peer/5.1.execution.from_vision._.review.i005.c730d4b3ba4ac80adf.r010._.taken.by_self.enroll-impl-behavior-intent.md
+   │  │   └─ r11: enroll-impl-arch-defects (l3, 3/3)
+   │  │       ├─ approved 414.2s
+   │  │       ├─ 0 blockers ✓
+   │  │       ├─ 1 nitpick 🟠
+   │  │       ├─ tallied by reviewer@fireworks/deepseek/v4-flash
+   │  │       ├─ given: .behavior/v2026_07_23.feat-surface-static-origin/.reviews/peer/5.1.execution.from_vision._.review.i005.c730d4b3ba4ac80adf.r011._.given.by_peer.enroll-impl-arch-defects.md
+   │  │       └─ taken: .behavior/v2026_07_23.feat-surface-static-origin/.reviews/peer/5.1.execution.from_vision._.review.i005.c730d4b3ba4ac80adf.r011._.taken.by_self.enroll-impl-arch-defects.md
+   │  └─ judges
+   │      └─ j1: $rhachet run --repo bhrain --skill route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 3
+   │          └─ finished 1.4s ✓
+   │
+   └─ the way continues, run
+      └─ rhx route.drive

--- a/.behavior/v2026_07_23.feat-surface-static-origin/5.1.execution.from_vision.stone
+++ b/.behavior/v2026_07_23.feat-surface-static-origin/5.1.execution.from_vision.stone
@@ -1,0 +1,15 @@
+bootup your mechanic's role via `./node_modules/.bin/rhachet roles boot --repo ehmpathy --role mechanic`
+
+then, execute the vision directly
+- .behavior/v2026_07_23.feat-surface-static-origin/1.vision.md
+
+ref:
+- .behavior/v2026_07_23.feat-surface-static-origin/0.wish.md
+
+
+---
+
+track your progress
+
+emit todos and check them off into
+- .behavior/v2026_07_23.feat-surface-static-origin/5.1.execution.from_vision.yield.md

--- a/.behavior/v2026_07_23.feat-surface-static-origin/5.1.execution.from_vision.yield.md
+++ b/.behavior/v2026_07_23.feat-surface-static-origin/5.1.execution.from_vision.yield.md
@@ -1,0 +1,68 @@
+# 5.1 execution — surface `static origin` on extracted metadata
+
+executed the approved vision directly. `origin` is now recognized on a domain-object class
+declaration and surfaced on `DomainObjectMetadata.decorations.origin`, mirroring `alias`.
+per the wisher decision (2026-07-23), **both** the bare-string and `as const` forms are
+supported.
+
+## todos
+
+- [x] add `origin: string | null` to the zod schema + interface `decorations`
+  (`src/domain.objects/DomainObjectMetadata.ts`)
+- [x] recognize `static origin` in the extractor, mirroring `alias`
+  (`extractRelevantStaticPropertiesFromClassDeclaration.ts`)
+- [x] support both `origin = '...'` (bare) and `origin = '...' as const` — extend
+  `getInitialValueOfStaticProperty` to unwrap an `AsExpression` around a `StringLiteral`
+- [x] thread `origin` into the `decorations` object in the assembler
+  (`extractDomainObjectMetadataForDeclarationInFile.ts`)
+- [x] add test assets bearing `static origin`: `SvcHomeServicesHomeService.ts` (`as const`,
+  the wish's literal example) + `SeaShell.ts` (bare string)
+- [x] update `extractRelevantStaticPropertiesFromClassDeclaration.test.ts` — extant
+  expectations gain `origin: null`; add two new cases (bare + `as const`)
+- [x] add a snapshot case for a non-null `origin` in
+  `extractDomainObjectMetadataForDeclarationInFile.test.ts` (+ explicit
+  `decorations.origin` assertion)
+- [x] fix `DomainObjectMetadata.test.ts` construction to include `origin: null`
+- [x] resnap the three snapshots that render `decorations` (extract, hydrate, introspect)
+- [x] green: types, lint, format, 39 unit tests
+
+## what changed (prod)
+
+- `src/domain.objects/DomainObjectMetadata.ts` — `origin: string | null` on the interface
+  and `origin: z.string().nullable()` on the zod schema, in the `decorations` bag
+- `src/domain.operations/extract/extractRelevantStaticPropertiesFromClassDeclaration.ts` —
+  extract `origin` like `alias`; `getInitialValueOfStaticProperty` now unwraps an
+  `AsExpression` that holds a `StringLiteral` so `origin = '...' as const` yields its text
+  rather than a fall-through to the array branch
+- `src/domain.operations/extract/extractDomainObjectMetadataForDeclarationInFile.ts` —
+  `origin` added to the `decorations` object
+
+## what changed (test)
+
+- new assets: `SvcHomeServicesHomeService.ts` (`as const`), `SeaShell.ts` (bare)
+- `extractRelevantStaticPropertiesFromClassDeclaration.test.ts` — `origin: null` on the four
+  extant expectations; two new `origin` cases (bare + `as const`)
+- `extractDomainObjectMetadataForDeclarationInFile.test.ts` — snapshot + explicit assertion
+  for a non-null `origin`
+- `DomainObjectMetadata.test.ts` — `origin: null` in the constructed `decorations`
+- resnapped: `extract/__snapshots__/…`, `hydrate/__snapshots__/…`,
+  `domain.operations/__snapshots__/introspect.test.ts.snap`
+
+## verification
+
+| check | result |
+|-------|--------|
+| `rhx git.repo.test --what types` | 🎉 passed |
+| `rhx git.repo.test --what unit` (resnap) | 🎉 39 passed, 0 failed |
+| `rhx git.repo.test --what lint` | 🎉 passed |
+| `rhx git.repo.test --what format` | 🎉 passed |
+
+the `as const` unwrap is proven end-to-end: the new extract snapshot renders
+`"origin": "ahbode/svc-home-services"` for the `as const` asset, and the bare-string asset
+asserts `origin: 'ehmpathy/svc-sea-registry'`. every extant object surfaces `origin: null`
+(prior behavior unchanged).
+
+## scope honored
+
+passthrough only — no schema inference, no column/table logic. the sql-dao-generator half
+of #27 is untouched (separate downstream behavior).

--- a/.behavior/v2026_07_23.feat-surface-static-origin/5.3.verification.guard
+++ b/.behavior/v2026_07_23.feat-surface-static-origin/5.3.verification.guard
@@ -1,0 +1,292 @@
+# provenance = self-referential source template; enables `rhx route.guard.upgrade` idempotency
+provenance:
+  uri: node_modules/rhachet-roles-bhuild/dist/domain.operations/behavior/init/templates/5.3.verification.guard
+
+artifacts:
+  # track verification progress
+  - "$route/5.3.verification.yield.md"
+  # track actual implementation in src/
+  - "src/**/*"
+
+reviews:
+  self:
+    - slug: has-behavior-coverage
+      say: |
+        double-check: does the verification checklist show every behavior from wish/vision has a test?
+
+        - is every behavior in 0.wish.md covered?
+        - is every behavior in 1.vision.md covered?
+        - can you point to each test file in the checklist?
+
+        **if any behavior lacks a test, write the test NOW.** do not pass this gate with gaps.
+
+    - slug: has-zero-test-skips
+      say: |
+        double-check: did you verify zero skips — and REMOVE any you found?
+
+        - no .skip() or .only() found?
+        - no silent credential bypasses?
+        - no prior failures carried forward?
+
+        **if you found skips, did you remove them and make those tests pass?**
+
+        this is buttonup. skips are gaps. gaps get fixed, not noted.
+
+    - slug: has-all-tests-passed
+      say: |
+        double-check: did all tests pass? prove it with a VERBATIM terminal block.
+
+        **zero unproven claims. a claim is not proof — only pasted output is.**
+
+        for EACH test suite you must paste, verbatim from your terminal:
+        - the exact command you ran
+        - the final summary line (counts)
+        - the exit code
+
+        required proof shape — paste your real run, not this template:
+        ```
+        $ npm run test:unit
+        > 47 passed, 0 failed, 0 skipped
+        > exit 0
+        ```
+
+        the articulation is REJECTED if it:
+        - says "all tests pass" without a pasted block
+        - paraphrases the result instead of a verbatim paste
+        - pastes a partial run (one suite) and claims the rest
+        - shows any non-zero exit, any failure, or any skip
+
+        if you did not paste the command AND its output AND the exit code, you did
+        not prove it — and an unproven pass is a feigned review.
+
+        zero tolerance for extant failures:
+        - "it was already broken" is not an excuse — fix it
+        - "it's unrelated to my changes" is not an excuse — fix it
+        - flaky tests must be stabilized, not tolerated
+        - every failure is your responsibility now
+
+        zero tolerance for flakes — when a test flakes, deflake it:
+        - a test that passes on re-run is not "fine" — it is a live defect
+        - do NOT retry until green and move on; that hides the flake for the next run
+        - run the structured deflake workflow: rhx cicd.deflake init
+        - diagnose the root cause (race, shared state, clock, unmasked volatile output),
+          repair it, and prove the fix holds across re-runs
+        - a masked volatile output (see the snapshot rules) is the usual fix for an
+          output-driven flake
+
+        zero tolerance for fake tests:
+        - tests that always pass are fraud
+        - tests that mock the system under test prove no behavior
+        - tests must verify real behavior
+
+        zero tolerance for credential excuses:
+        - "i don't have creds" means get them or mock them
+        - silent bypasses are forbidden
+        - if creds block tests, that is a BLOCKER — not a deferral
+
+    - slug: has-preserved-test-intentions
+      say: |
+        double-check: did you preserve test intentions?
+
+        for every test you touched:
+        - what did this test verify before?
+        - does it still verify the same behavior after?
+        - did you change what the test asserts, or fix why it failed?
+
+        forbidden:
+        - weaken assertions to make tests pass
+        - remove test cases that "no longer apply"
+        - change expected values to match broken output
+        - delete tests that fail instead of fix code
+
+        the test knew a truth. if it failed, either:
+        - the code is wrong — fix the code
+        - the test has a bug — fix the bug, keep the intention
+        - requirements changed — document why, get approval
+
+        to "fix tests" via changed intent is not a fix — it is at worst
+        malicious deception, at best reckless negligence. unacceptable.
+
+    - slug: has-snap-changes-rationalized
+      say: |
+        double-check: is every `.snap` file change intentional and justified?
+
+        for each `.snap` file in git diff:
+        1. what changed? (added, modified, deleted)
+        2. was this change intended or accidental?
+        3. if intended: what is the rationale?
+        4. if accidental: revert it or explain why the new output is an improvement
+
+        common regressions caught here:
+        - output format degraded (lost alignment, lost structure)
+        - error messages became less helpful
+        - timestamps or ids leaked into snapshots (flaky)
+        - extra output added unintentionally
+
+        forbidden:
+        - "updated snapshots" without per-file rationale
+        - bulk snapshot updates without review
+        - regressions accepted without justification
+
+        every snap change tells a story. make sure the story is intentional.
+
+    - slug: has-critical-paths-frictionless
+      say: |
+        double-check: are the critical paths frictionless in practice? prove it with a
+        pasted runthrough, not a claim of "smooth".
+
+        "frictionless" is not a vibe — it is a concrete rubric. read the ergonomist
+        brief `def.frictionless` (in your booted ergonomist briefs) and score against it.
+
+        find the critical paths. if a repros artifact exists, take them from it:
+        - .behavior/v2026_07_23.feat-surface-static-origin/3.2.distill.repros.experience.*.md
+        if no repros artifact exists, take the critical paths straight from the
+        wish + vision (the primary usecases a human runs) — absence of repros is
+        NOT an excuse to skip this review.
+
+        for EACH critical path, paste verbatim from your terminal:
+        - the exact command(s) you ran to walk the path
+        - the real output they produced
+
+        then score that pasted output against every criterion in def.frictionless,
+        one line each.
+
+        the articulation is REJECTED if it:
+        - claims "smooth" or "frictionless" without a pasted runthrough
+        - paraphrases the outcome instead of a verbatim paste
+        - walks only one path and claims the rest
+        - skips the review because repros is absent
+
+        a claim of frictionless is not proof — a pasted session scored against
+        def.frictionless is. if the paste shows friction, fix it NOW; do not note it.
+
+    - slug: has-ergonomics-validated
+      say: |
+        double-check: is the actual input/output ergonomic? prove it with a pasted
+        capture of the real i/o, not a claim of "matches".
+
+        "ergonomics" is not a vibe — it is a concrete rubric. read the ergonomist
+        brief `def.ergonomic` (in your booted ergonomist briefs) and score against it.
+
+        for EACH critical path, capture the real i/o verbatim from the built
+        artifact's run and paste it.
+
+        then choose ONE frame:
+        - if a repros artifact exists (.behavior/v2026_07_23.feat-surface-static-origin/3.2.distill.repros.experience.*.md),
+          paste a two-column comparison — planned i/o (from repros) vs actual i/o
+          (captured) — and flag any drift between them.
+        - if no repros artifact exists, score the captured i/o directly against every
+          criterion in def.ergonomic, one line each. absence of repros is NOT an
+          excuse to skip this review.
+
+        the articulation is REJECTED if it:
+        - claims "matches" or "ergonomic" without the pasted capture
+        - fills the actual/captured column with a paraphrase instead of real output
+        - skips the review because repros is absent
+
+        if the ergonomics fall short, either:
+        - update repros to reflect the better design (when repros exists), or
+        - fix the implementation to meet the def.ergonomic rubric
+
+        drift you cannot see in a paste is drift you did not check.
+
+    - slug: has-fixed-all-gaps
+      say: |
+        final buttonup check: did you FIX every gap you found, or just detect it?
+
+        **this is the buttonup phase. detection is not enough — you must fix.**
+
+        look back at all the reviews above. for every gap you identified:
+        - absent test coverage → did you WRITE the test?
+        - absent prod coverage → did you IMPLEMENT the behavior?
+        - failed test → did you FIX the code or test?
+        - skipped test → did you REMOVE the skip and make it pass?
+
+        **zero omissions.** if any review above surfaced a gap, that gap must be fixed before you pass this gate.
+
+        ask yourself:
+        - did i just note the gap, or did i actually fix it?
+        - is there any item marked "todo" or "later"? (forbidden)
+        - is there any coverage marked incomplete? (forbidden)
+
+        **if you detected it, you fixed it.** prove it — a bare "all fixed" is a feigned review.
+
+        this review is the closer. the articulation must ENUMERATE, not summarize.
+        for EACH gap any review above surfaced, write one line:
+
+        - the gap (which review found it, what it was)
+        - the fix (the exact file + what changed, or the commit/diff reference)
+
+        if a review above found no gap, say so per review — do not skip it silently.
+
+        the articulation is REJECTED if it:
+        - says "all gaps fixed" without the per-gap enumeration
+        - references a fix with no file/diff pointer
+        - leaves any surfaced gap unaddressed
+
+        this is the final self-review. you are about to hand off to peer review.
+        prove every item above was addressed — with a pointer — not deferred.
+
+  peer:
+    # --- level 1: cheap reviewers (run first, in parallel) ---
+
+    - slug: repo-rules
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=.this/**/rule.*.md' --optional rules --diffs since-main --paths-with '**/*.{ts,sh}' --join intersect --conversation $conversation --output "$output"
+      budget: 3
+      level: 1
+
+    - slug: ergo-contract-snapshots
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/rule.require.contract-snapshot-exhaustiveness.md' --refs '.agent/repo=ehmpathy/role=ergonomist/briefs/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.coverage/*.md' --refs '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/*.md' --diffs since-main --paths-with '**/*.{ts,sh}' --paths-with '**/*.snap' --join intersect --conversation $conversation --output "$output"
+      budget: 3
+      level: 1
+
+    - slug: mech-external-contracts
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/rule.require.external-contract-integration-tests.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.coverage/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.unit/rule.forbid.remote-boundaries.md' --diffs since-main --paths-with '**/*.{ts,sh}' --paths-with '**/*.snap' --join intersect --conversation $conversation --output "$output"
+      budget: 3
+      level: 1
+
+    - slug: ergo-acceptance-journey-coverage
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/ergonomist/rule.require.acceptance-journey-coverage.md' --refs '.agent/repo=ehmpathy/role=ergonomist/briefs/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/frames.behavior/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.coverage/*.md' --refs '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/*.md' --diffs since-main --paths-with '**/*.{ts,sh}' --paths-with '**/*.snap' --join intersect --conversation $conversation --output "$output"
+      budget: 3
+      level: 1
+
+    - slug: ergo-snapshot-visual-blemishes
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/ergonomist/rule.forbid.snapshot-visual-blemishes.md' --refs '.agent/repo=ehmpathy/role=ergonomist/briefs/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/lang.tones/*.md.min' --refs '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/rule.require.contract-snapshot-exhaustiveness.md' --diffs since-main --paths-with '**/*.{ts,sh}' --paths-with '**/*.snap' --join intersect --conversation $conversation --output "$output"
+      budget: 3
+      level: 1
+
+    - slug: mech-given-when-then
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/frames.behavior/rule.require.given-when-then.md' --refs '.agent/repo=ehmpathy/role=architect/briefs/criteria.given_when_then.[seed].v3.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/frames.behavior/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/lessons.howto/*.md.min' --diffs since-main --paths-with '**/*.test.ts' --paths-with '**/*.snap' --join intersect --conversation $conversation --output "$output"
+      budget: 3
+      level: 1
+
+    - slug: mech-test-intent
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/rule.forbid.test-intent-violations.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.coverage/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/work.flow/refactor/rule.require.review-test-changes.md.min' --diffs since-main --paths-with '**/*.test.ts' --paths-with '**/*.snap' --join intersect --conversation $conversation --output "$output"
+      budget: 3
+      level: 1
+
+    - slug: mech-test-scope-purity
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.*/rule.*.md' --diffs since-main --paths-with '{src,blackbox}/**/*.test.ts' --join intersect --conversation $conversation --output "$output"
+      budget: 3
+      level: 1
+
+    # --- level 3: expensive reviewers (run after level 1 is terminal) ---
+
+    - slug: enroll-verif-snapshot-coverage
+      run: $rhx enroll claude --model 'claude-sonnet-5[1m]' --roles reviewer,behaver,ergonomist,mechanic -p 'review the diff for snapshot coverage on contract endpoints and acceptance test user journey coverage. read the prior peer-review conversation at $conversation to catch up on context.'
+      budget: 3
+      level: 3
+
+    - slug: enroll-verif-snapshot-blemishes
+      run: $rhx enroll claude --model 'claude-sonnet-5[1m]' --roles reviewer,behaver,ergonomist,mechanic -p 'review the diff for experiential and visual blemishes in snapshotted acceptance test journeys. read the prior peer-review conversation at $conversation to catch up on context.'
+      budget: 3
+      level: 3
+
+    - slug: enroll-verif-test-intent
+      run: $rhx enroll claude --model 'claude-sonnet-5[1m]' --roles reviewer,behaver,architect,mechanic -p 'review the current implementation for test intent violation diffs. if any of the diffs related to tests loosened assertions or changed the criteria, this is a blocker. tests were added for a reason. we have to maintain the behavior they locked in. read the prior peer-review conversation at $conversation to catch up on context.'
+      budget: 3
+      level: 3
+
+judges:
+  # enforce peer reviews pass with zero blockers
+  - $rhachet run --repo bhrain --skill route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 0

--- a/.behavior/v2026_07_23.feat-surface-static-origin/5.3.verification.stamp
+++ b/.behavior/v2026_07_23.feat-surface-static-origin/5.3.verification.stamp
@@ -1,0 +1,70 @@
+🦉 the way speaks for itself
+
+🗿 route.stone.set
+   ├─ stone = 5.3.verification
+   ├─ passage = allowed
+   ├─ guard
+   │  ├─ artifacts
+   │  │   ├─ $route/5.3.verification.yield.md
+   │  │   └─ src/**/*
+   │  ├─ reviews
+   │  │   ├─ r1: repo-rules (l1, 1/3)
+   │  │   │   ├─ approved, cached
+   │  │   │   ├─ 0 blockers ✓
+   │  │   │   ├─ 0 nitpicks ✓
+   │  │   │   ├─ given: .behavior/v2026_07_23.feat-surface-static-origin/.reviews/peer/5.3.verification._.review.i001.cd22e710d7c4b8b27f.r001._.given.by_peer.repo-rules.md
+   │  │   │   └─ taken: .behavior/v2026_07_23.feat-surface-static-origin/.reviews/peer/5.3.verification._.review.i001.cd22e710d7c4b8b27f.r001._.taken.by_self.repo-rules.md
+   │  │   ├─ r2: ergo-contract-snapshots (l1, 1/3)
+   │  │   │   ├─ approved, cached
+   │  │   │   ├─ 0 blockers ✓
+   │  │   │   ├─ 0 nitpicks ✓
+   │  │   │   ├─ given: .behavior/v2026_07_23.feat-surface-static-origin/.reviews/peer/5.3.verification._.review.i001.cd22e710d7c4b8b27f.r002._.given.by_peer.ergo-contract-snapshots.md
+   │  │   │   └─ taken: .behavior/v2026_07_23.feat-surface-static-origin/.reviews/peer/5.3.verification._.review.i001.cd22e710d7c4b8b27f.r002._.taken.by_self.ergo-contract-snapshots.md
+   │  │   ├─ r3: mech-external-contracts (l1, 1/3)
+   │  │   │   ├─ approved, cached
+   │  │   │   ├─ 0 blockers ✓
+   │  │   │   ├─ 0 nitpicks ✓
+   │  │   │   ├─ given: .behavior/v2026_07_23.feat-surface-static-origin/.reviews/peer/5.3.verification._.review.i001.cd22e710d7c4b8b27f.r003._.given.by_peer.mech-external-contracts.md
+   │  │   │   └─ taken: .behavior/v2026_07_23.feat-surface-static-origin/.reviews/peer/5.3.verification._.review.i001.cd22e710d7c4b8b27f.r003._.taken.by_self.mech-external-contracts.md
+   │  │   ├─ r4: ergo-acceptance-journey-coverage (l1, 1/3)
+   │  │   │   ├─ approved, cached
+   │  │   │   ├─ 0 blockers ✓
+   │  │   │   ├─ 0 nitpicks ✓
+   │  │   │   ├─ given: .behavior/v2026_07_23.feat-surface-static-origin/.reviews/peer/5.3.verification._.review.i001.cd22e710d7c4b8b27f.r004._.given.by_peer.ergo-acceptance-journey-coverage.md
+   │  │   │   └─ taken: .behavior/v2026_07_23.feat-surface-static-origin/.reviews/peer/5.3.verification._.review.i001.cd22e710d7c4b8b27f.r004._.taken.by_self.ergo-acceptance-journey-coverage.md
+   │  │   ├─ r5: ergo-snapshot-visual-blemishes (l1, 1/3)
+   │  │   │   ├─ approved, cached
+   │  │   │   ├─ 0 blockers ✓
+   │  │   │   ├─ 0 nitpicks ✓
+   │  │   │   ├─ given: .behavior/v2026_07_23.feat-surface-static-origin/.reviews/peer/5.3.verification._.review.i001.cd22e710d7c4b8b27f.r005._.given.by_peer.ergo-snapshot-visual-blemishes.md
+   │  │   │   └─ taken: .behavior/v2026_07_23.feat-surface-static-origin/.reviews/peer/5.3.verification._.review.i001.cd22e710d7c4b8b27f.r005._.taken.by_self.ergo-snapshot-visual-blemishes.md
+   │  │   ├─ r6: mech-given-when-then (l1, 1/3)
+   │  │   │   ├─ approved, cached
+   │  │   │   ├─ 0 blockers ✓
+   │  │   │   ├─ 0 nitpicks ✓
+   │  │   │   ├─ given: .behavior/v2026_07_23.feat-surface-static-origin/.reviews/peer/5.3.verification._.review.i001.cd22e710d7c4b8b27f.r006._.given.by_peer.mech-given-when-then.md
+   │  │   │   └─ taken: .behavior/v2026_07_23.feat-surface-static-origin/.reviews/peer/5.3.verification._.review.i001.cd22e710d7c4b8b27f.r006._.taken.by_self.mech-given-when-then.md
+   │  │   ├─ r7: mech-test-intent (l1, 1/3)
+   │  │   │   ├─ approved, cached
+   │  │   │   ├─ 0 blockers ✓
+   │  │   │   ├─ 0 nitpicks ✓
+   │  │   │   ├─ given: .behavior/v2026_07_23.feat-surface-static-origin/.reviews/peer/5.3.verification._.review.i001.cd22e710d7c4b8b27f.r007._.given.by_peer.mech-test-intent.md
+   │  │   │   └─ taken: .behavior/v2026_07_23.feat-surface-static-origin/.reviews/peer/5.3.verification._.review.i001.cd22e710d7c4b8b27f.r007._.taken.by_self.mech-test-intent.md
+   │  │   ├─ r8: mech-test-scope-purity (l1, 2/3)
+   │  │   │   ├─ rejected 14.4s
+   │  │   │   ├─ 0 blockers ✓
+   │  │   │   ├─ 0 nitpicks ✓
+   │  │   │   ├─ given: .behavior/v2026_07_23.feat-surface-static-origin/.reviews/peer/5.3.verification._.review.i002.cd22e710d7c4b8b27f.r008._.given.by_peer.mech-test-scope-purity.md
+   │  │   │   └─ taken: .behavior/v2026_07_23.feat-surface-static-origin/.reviews/peer/5.3.verification._.review.i002.cd22e710d7c4b8b27f.r008._.taken.by_self.mech-test-scope-purity.md
+   │  │   ├─ r9: enroll-verif-snapshot-coverage (l3, 1/3)
+   │  │   │   └─ awaits l1 terminal
+   │  │   ├─ r10: enroll-verif-snapshot-blemishes (l3, 1/3)
+   │  │   │   └─ awaits l1 terminal
+   │  │   └─ r11: enroll-verif-test-intent (l3, 1/3)
+   │  │       └─ awaits l1 terminal
+   │  └─ judges
+   │      └─ j1: $rhachet run --repo bhrain --skill route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 0
+   │          └─ finished 1.3s ✓
+   │
+   └─ the way continues, run
+      └─ rhx route.drive

--- a/.behavior/v2026_07_23.feat-surface-static-origin/5.3.verification.stone
+++ b/.behavior/v2026_07_23.feat-surface-static-origin/5.3.verification.stone
@@ -1,0 +1,304 @@
+prove the deliverable works via test verification — fix all gaps
+
+---
+
+## .what
+
+this is the verification gate — the **buttonup phase**.
+
+you cannot pass execution without proof that all tests pass. more importantly: **test coverage enforces prod coverage**. if tests are absent, prod is incomplete. if prod is incomplete, fix it.
+
+## .the buttonup mandate: zero omissions
+
+**this is not a detection phase. this is a completion phase.**
+
+when you find a gap, you do not note it and move on. you **fix it**.
+
+| gap type | action |
+|----------|--------|
+| absent test coverage | write the test NOW |
+| absent prod coverage | implement the behavior NOW |
+| failed test | fix the code or fix the test NOW |
+| skipped test | remove the skip and make it pass NOW |
+
+**if you detect it, you fix it. no exceptions.**
+
+## .strictness: zero tolerance, zero exceptions
+
+**this gate enforces absolute standards. there is no leniency.**
+
+| constraint | definition |
+|------------|------------|
+| zero deferrals | you cannot defer any test to later. all tests pass now or you fail. |
+| zero fake tests | tests must verify real behavior. assertions that always pass are fraud. |
+| zero unproven claims | every claim of "test passes" must cite the exact command run and output. |
+| zero credential excuses | "i don't have creds" is not an excuse. get them, mock them, or fail. |
+| zero skips | .skip() and .only() are forbidden. silent bypasses are forbidden. |
+| zero exceptions | there are no special cases. the rules apply to all. |
+| zero omissions | if you find a gap in coverage, you fix it — test or prod. |
+
+**if a blocker prevents tests from run, that is a BLOCKER. full stop.**
+
+you do not proceed. you do not defer. you fix it or you fail the gate.
+
+## .why
+
+**why does this gate exist?**
+
+your crew is about to review a pr you wrote. they need proof it works — not words, proof. tests are that proof.
+
+**test coverage drives prod coverage.** if a behavior lacks a test, that behavior is unproven. unproven behaviors are incomplete deliverables. the test proves the implementation exists and works.
+
+without this gate:
+- tests might fail and nobody notices
+- tests might be skipped and nobody notices
+- behaviors might lack coverage and nobody notices
+- broken code ships to peers
+- incomplete implementations slip through
+
+with this gate:
+- every test passes or you fix it
+- every behavior has coverage or you add it
+- every skip is removed or justified
+- proven code ships to peers
+- **gaps get fixed, not deferred**
+
+**the cardinal rules**:
+1. never leave behavior without true, dependable test coverage
+2. never offload work onto your crew unless there is truly, fundamentally no other option
+3. never claim a test passes without cite of the exact command and output
+
+you fix it yourself. you exhaust every option: debug, research, try alternatives. only when you hit a wall that is physically impossible to climb alone — credentials only the foreman possesses, access only they can grant — only then may you ask for help.
+
+## .how
+
+reference the below for full context
+- .behavior/v2026_07_23.feat-surface-static-origin/0.wish.md
+- .behavior/v2026_07_23.feat-surface-static-origin/1.vision.md
+- .behavior/v2026_07_23.feat-surface-static-origin/2.1.criteria.blackbox.md (if declared)
+- .behavior/v2026_07_23.feat-surface-static-origin/3.2.distill.repros.experience.*.md (if declared) ← **repros artifact**
+
+---
+
+### step 1: emit verification checklist
+
+emit to
+- .behavior/v2026_07_23.feat-surface-static-origin/5.3.verification.yield.md
+
+this is your roadmap. emit it first, then work through it step by step.
+
+**checklist structure:**
+
+```
+## verification checklist
+
+### behavior coverage (with reference to repros)
+
+for each journey sketched in repros, verify it was implemented with snapshots.
+
+| journey (from repros) | test file | snapshots? | critical path? | ergonomics ok? | status |
+|-----------------------|-----------|------------|----------------|----------------|--------|
+| {journey 1}           | {path}    | ✓ / ✗      | ✓ frictionless / needs work | ✓ natural / needs work | ⏳ |
+| {journey 2}           | {path}    | ✓ / ✗      | ✓ frictionless / needs work | ✓ natural / needs work | ⏳ |
+...
+
+### zero skips verified
+- [ ] no .skip() or .only() found
+- [ ] no silent credential bypasses
+- [ ] no prior failures carried forward
+
+### snapshot coverage for contract outputs
+
+each public contract needs dedicated snapshots that demonstrate its stdout for:
+- **vibechecks in prs** — reviewers see actual output without executing code
+- **drift detection** — changes to output surface in diffs over time
+
+| contract | output variants | snapshot file | status |
+|----------|-----------------|---------------|--------|
+| {command 1} | success, error, help | {path.snap} | ⏳ |
+| {command 2} | success, error, help | {path.snap} | ⏳ |
+...
+
+checklist:
+- [ ] every new cli command has `.snap` snapshots for stdout/stderr
+- [ ] every new app screen has `.snap` snapshots for screenshots
+- [ ] every new sdk method has `.snap` snapshots for responses
+- [ ] each output variant is exercised (success, error, edge cases)
+- [ ] snapshots demonstrate actual output, not just "it ran"
+
+### snapshot change rationalization
+
+for each `.snap` file changed, rationalize whether the change was intended or accidental:
+
+| snap file | change type | intended? | rationale |
+|-----------|-------------|-----------|-----------|
+| {path.snap} | added / modified / deleted | yes / no | {why this change is correct} |
+...
+
+checklist:
+- [ ] every `.snap` change has been reviewed
+- [ ] intended changes have clear rationale
+- [ ] accidental changes have been reverted or justified as improvements
+
+### tests executed — with proof
+
+**every test run must be proven with exact command and output.**
+
+| test suite | command run | result | proof (exit code + summary) |
+|------------|-------------|--------|----------------------------|
+| types | `npm run test:types` | ✓ / ✗ | exit 0, no errors |
+| lint | `npm run test:lint` | ✓ / ✗ | exit 0, no errors |
+| format | `npm run test:format` | ✓ / ✗ | exit 0, no errors |
+| unit | `npm run test:unit` | ✓ / ✗ | exit 0, N tests passed |
+| integration | `npm run test:integration` | ✓ / ✗ | exit 0, N tests passed |
+| acceptance | `npm run test:acceptance` | ✓ / ✗ | exit 0, N tests passed |
+
+checklist:
+- [ ] every test command was run (not "i think it passed")
+- [ ] every test command output was observed (not assumed)
+- [ ] the exact exit code was verified (0 = pass, non-zero = fail)
+- [ ] no tests were skipped, mocked, or faked
+
+**zero unproven claims.** if you claim a test passes, cite the command and output.
+
+### contract output snapshot exhaustiveness
+
+**every user-faced contract must have exhaustive snapshot coverage.**
+
+| contract type | contract | positive path snapped? | negative path snapped? | edge cases snapped? |
+|---------------|----------|------------------------|------------------------|---------------------|
+| cli | {command} | ✓ / ✗ | ✓ / ✗ | ✓ / ✗ |
+| api | {endpoint} | ✓ / ✗ | ✓ / ✗ | ✓ / ✗ |
+| sdk | {method} | ✓ / ✗ | ✓ / ✗ | ✓ / ✗ |
+
+checklist:
+- [ ] every cli command has stdout/stderr snapshots for success, error, and help
+- [ ] every api endpoint has response snapshots for success and error codes
+- [ ] every sdk method has return value snapshots for success and error
+- [ ] every contract has edge case snapshots (empty input, invalid input, boundary)
+
+**zero gaps in caller experience.** the reviewer must see exactly what callers see.
+
+### blockers
+- none (or list handoff references)
+```
+
+update the checklist as you complete each step below.
+
+---
+
+### step 2: verify AND FIX behavior coverage
+
+walk through wish and vision:
+- every behavior promised must have an acceptance test
+- for each behavior, you can point to the test file
+- no behavior left untested
+
+**why?** your crew trusts the test suite. if a behavior isn't tested, it isn't proven. untested behaviors are unverified promises.
+
+**test coverage enforces prod coverage.** if a test is absent, either:
+1. the behavior was not implemented → IMPLEMENT IT NOW
+2. the behavior was implemented without a test → WRITE THE TEST NOW
+
+if a behavior lacks a test, **write one NOW**. do not move on with gaps. update your checklist when done.
+
+---
+
+### step 3: verify AND FIX zero skips
+
+scan for forbidden patterns:
+- `.skip()` or `.only()` in test files
+- `if (!credentials) return` or similar silent bypasses
+- prior failures carried forward (known-broken tests)
+
+**why?** failures are better than skips. skips hide problems. failures expose them. a skipped test is a lie — it pretends coverage exists when it doesn't.
+
+**this is buttonup.** if you find skips:
+1. REMOVE the skip
+2. MAKE the test pass (fix the code or fix the test)
+3. update your checklist
+
+do not note skips and move on. fix them. all tests must run.
+
+---
+
+### step 4: run all tests AND FIX all failures
+
+run each test suite and **cite the exact command and output**.
+
+```bash
+npm run test:types      # cite exit code
+npm run test:lint       # cite exit code
+npm run test:format     # cite exit code
+npm run test:unit       # cite exit code + test count
+npm run test:integration # cite exit code + test count
+npm run test:acceptance  # cite exit code + test count
+```
+
+all must pass — no exceptions. no deferrals. no "i'll fix it later."
+
+**this is buttonup.** if tests fail, fix them. that is the job.
+
+failures indicate one of:
+1. prod code is broken → FIX THE PROD CODE
+2. test has a bug → FIX THE TEST BUG (preserve intention)
+3. coverage gap exists → FILL THE GAP
+
+**consider all failures as defects from this pr.** there are no "prior failures."
+
+if a test was broken before you started — fix it. if a test is flaky — fix it. if a test fails for reasons unrelated to your changes — fix it anyway. you do not get to say "that was already broken." you are here now. you fix it.
+
+**take initiative. take ownership.**
+
+**preserve test intentions.** when you fix a test, you fix why it failed — not what it tests. to change what a test verifies is not a fix. it is at worst malicious deception, at best reckless negligence. the test knew a truth. if it fails, either the code is wrong or the test has a bug. fix the cause, not the assertion.
+
+**zero fake tests.** a test that always passes is fraud. a test that skips is a lie. a test that mocks the system under test proves nothingness. tests must verify real behavior against real code.
+
+**escalation path:**
+1. debug the failure — read the error, understand the cause
+2. research — search for similar issues, read docs
+3. try alternatives — different approach, different tool
+4. ask for help — other resources, other clones
+5. deeper research — exhaust every option
+6. only if insurmountable — emit handoff (see step 5)
+
+**ask yourself at each level:**
+- did i read the error message carefully?
+- did i search for similar issues?
+- did i try a different approach?
+- did i isolate the problem?
+- did i ask for help?
+- did i exhaust every option?
+
+you move to handoff only when you can answer "yes" to all of the above and still cannot proceed.
+
+update your checklist when all tests pass.
+
+---
+
+### step 5: handoff (only if insurmountable)
+
+a handoff is a document that transfers work to your foreman because you hit a wall that is physically impossible to climb alone.
+
+**foreman-only blockers:**
+- credentials only the foreman possesses
+- external access only the foreman can grant
+- approval that requires foreman authority
+
+handoff is the absolute last resort. you must exhaust every option before you consider it.
+
+if you need to emit a handoff:
+
+emit to
+- .behavior/v2026_07_23.feat-surface-static-origin/5.3.verification.handoff.v$N.to_foreman.md
+
+**handoff must include:**
+1. what you tried (list every approach you attempted)
+2. why each approach failed (be specific)
+3. what makes this fundamentally impossible without foreman intervention
+4. is this truly a "foreman possesses the key" situation?
+5. rewind instruction: `rhx route.stone.set --stone 5.3.verification --as rewound`
+
+your crew should read your handoff and think: "yes, there was truly no other way."
+
+update your checklist to reference the handoff.

--- a/.behavior/v2026_07_23.feat-surface-static-origin/5.3.verification.yield.md
+++ b/.behavior/v2026_07_23.feat-surface-static-origin/5.3.verification.yield.md
@@ -1,0 +1,85 @@
+# 5.3 verification — buttonup checklist
+
+## verification checklist
+
+### behavior coverage (vs wish + vision)
+
+this deliverable is an sdk/library (ast type-introspection), not a cli/app. its contract
+is the exported `introspect()` function and the `DomainObjectMetadata` type. coverage is
+proven via unit tests + jest snapshots at the extractor, assembler, introspect, and
+hydrate layers — mirroring how `alias`/`primary`/`unique` are already covered.
+
+| behavior (from wish/vision) | test file | snapshots? | status |
+|-----------------------------|-----------|------------|--------|
+| surface `origin` from `static origin = '...'` (bare string) | `extract/extractRelevantStaticPropertiesFromClassDeclaration.test.ts` (SeaShell asset) | n/a (equality) | ✓ |
+| surface `origin` from `static origin = '...' as const` | `extract/extractRelevantStaticPropertiesFromClassDeclaration.test.ts` (SvcHomeServicesHomeService asset) | n/a (equality) | ✓ |
+| shared `as const` string-unwrap also holds for sibling `alias` | `extract/extractRelevantStaticPropertiesFromClassDeclaration.test.ts` (AsyncTaskRideWaves asset) | n/a (equality) | ✓ |
+| absence of `origin` → `null` (not undefined) | same file (Payment, Address, SeaTurtle, AsyncTaskDoCoolStuff assets) | n/a (equality) | ✓ |
+| `origin` threaded onto `decorations.origin` by assembler | `extract/extractDomainObjectMetadataForDeclarationInFile.test.ts` | ✓ | ✓ |
+| `origin` surfaced end-to-end via `introspect()` | `introspect.test.ts` (explicit `decorations.origin` equality + snapshot) | ✓ | ✓ |
+| `origin` present in `DomainObjectMetadata` schema + interface | `domain.objects/DomainObjectMetadata.test.ts` | n/a (construct) | ✓ |
+| no variant gate — recognized on any DomainObject variant (mirrors `alias`) | assembler + introspect tests | ✓ | ✓ |
+
+no promised behavior left untested. scope held to the metadata half — no leak into
+`sql-dao-generator` (confirmed by arch-smell-scopeleaks peer review, 0 blockers).
+
+### zero skips verified
+- [x] no `.skip()` / `.only()` / `xit` / `xdescribe` found (grep over `src/**/*.ts` → 0 matches)
+- [x] no silent credential bypasses (no `if (!creds) return`; this lib needs no creds)
+- [x] no prior failures carried forward (full thorough suite green, 0 failed)
+
+### snapshot coverage for contract outputs
+
+the sdk's observable output is the `DomainObjectMetadata[]` returned by `introspect()`.
+snapshots capture that shape at three layers.
+
+| layer | output variant | snapshot file | status |
+|-------|----------------|---------------|--------|
+| introspect (e2e) | entity owned by another service via `origin` | `__snapshots__/introspect.test.ts.snap` | ✓ |
+| introspect (e2e) | entities without `origin` (Address/Delivery/DeliveryVan) | `__snapshots__/introspect.test.ts.snap` | ✓ |
+| assembler | `origin` present + `origin` absent | `extract/__snapshots__/extractDomainObjectMetadataForDeclarationInFile.test.ts.snap` | ✓ |
+| hydrate | additive `origin: null` across all fixtures | `hydrate/__snapshots__/getHydratedDomainObjectMetadatasFromFiles.test.ts.snap` | ✓ |
+
+- [x] every output variant is exercised (origin present + origin absent)
+- [x] snapshots demonstrate actual returned metadata, not just "it ran"
+
+### snapshot change rationalization
+
+| snap file | change type | intended? | rationale |
+|-----------|-------------|-----------|-----------|
+| `introspect.test.ts.snap` | added + modified | yes | new block for the origin asset (`"origin": "ahbode/svc-home-services"`); every other object gains a clean additive `"origin": null` line. no lines removed or reordered. |
+| `extractDomainObjectMetadataForDeclarationInFile.test.ts.snap` | added + modified | yes | new block for the origin asset; extant objects gain additive `"origin": null`. |
+| `getHydratedDomainObjectMetadatasFromFiles.test.ts.snap` | modified | yes | every fixture gains additive `"origin": null` — expected, since `decorations` now always carries the `origin` key. |
+
+- [x] every `.snap` change reviewed (git diff inspected line by line)
+- [x] all changes are additive `origin` entries — no accidental removals/reorders
+
+### tests executed — with proof
+
+| test suite | command run | result | proof |
+|------------|-------------|--------|-------|
+| types | `rhx git.repo.test --what types` | ✓ | exit 0, no errors (4s) |
+| lint | `rhx git.repo.test --what lint` | ✓ | exit 0 — biome + cycles + depcheck all clean (14s) |
+| format | `rhx git.repo.test --what format` | ✓ | exit 0 (1s) |
+| unit (thorough) | `rhx git.repo.test --what unit --mode apply --thorough` | ✓ | exit 0 — 14 suites, 46 passed, 0 failed, 0 skipped (34s) |
+| integration | n/a | n/a | 0 `*.integration.test.ts` files — pure introspection lib, no remote boundaries |
+| acceptance | n/a | n/a | 0 `*.acceptance.test.ts` files — sdk verified via unit + snapshots |
+
+- [x] every applicable test command was run and its output observed
+- [x] exact exit code verified (0 = pass) for each
+- [x] no tests skipped, mocked, or faked
+
+### contract output snapshot exhaustiveness
+
+| contract type | contract | positive path snapped? | negative path snapped? | edge cases snapped? |
+|---------------|----------|------------------------|------------------------|---------------------|
+| sdk | `introspect()` → `decorations.origin` | ✓ (origin present) | ✓ (origin absent → null) | ✓ (bare string + `as const` forms) |
+
+- [x] positive path (origin set) snapped at introspect + assembler layers
+- [x] negative path (origin absent → null) snapped across all fixtures
+- [x] edge cases (bare-string vs `as const`) covered via equality assertions on dedicated assets
+
+### blockers
+- none. all execution-stone peer reviews converged to 0 blockers / 0 nitpicks (i005); the
+  one l3-flagged coverage gap (shared `as const` unwrap untested for `alias`) was closed by
+  the `AsyncTaskRideWaves` asset + test case.

--- a/.behavior/v2026_07_23.feat-surface-static-origin/blocker/5.1.execution.from_vision.md
+++ b/.behavior/v2026_07_23.feat-surface-static-origin/blocker/5.1.execution.from_vision.md
@@ -1,0 +1,54 @@
+# blocker — 5.1.execution.from_vision
+
+## what blocks me
+
+the peer-review guard cannot complete: 8 of the 9 peer reviewers `💥 malfunction` with a
+hard configuration error — the brain they are pointed at is not installed in this
+environment.
+
+```
+BrainChoiceNotFoundError: brain not found: fireworks/deepseek/v4-flash
+```
+
+- **r1: repo-rules → approved (0 blockers, 0 nitpicks)** — it uses an available brain.
+- **r2–r9** (mech-failhides, mech-decode-friction, arch-opport-decomposition,
+  arch-smell-scopeleaks, arch-hazards-maintenance, arch-hazards-behavior,
+  behavior-intent-coverage, ergo-friction-hazards) — **all malfunction** on the absent brain
+  `fireworks/deepseek/v4-flash`.
+
+the available brains in this environment are anthropic (`claude/opus|sonnet|haiku|code`) and
+xai (`grok/*`) only — there is no `fireworks/deepseek` provider. this is an **environment /
+infrastructure gap**, not a review result: the reviewers never ran, so there is no verdict to
+converge with. per `contract.reviewer-output`, an unreadable review is treated as a
+malfunction that blocks — correctly, but the cause here is an absent brain, not a bad diff.
+
+## what i tried
+
+- ran `--as passed`; the guard triggered the 9 peer reviews. r1 approved 0/0; r2–r9 each
+  threw `BrainChoiceNotFoundError` (read the `given.by_peer.*.md` files to confirm — all the
+  same stack trace from `genContextBrain.js` → `buildContextBrain`).
+- verified the implementation itself is sound and green **before** the peer step:
+  - `rhx git.repo.test --what types` → passed
+  - `rhx git.repo.test --what unit` → **40 passed, 0 failed, 0 skipped** (3 snapshots
+    resnapped: extract, hydrate, introspect)
+  - `rhx git.repo.test --what lint` → passed
+  - `rhx git.repo.test --what format` → passed
+  - all 8 execution self-reviews promised (yagni, backcompat, consistent-mechanisms,
+    consistent-conventions, coverage, adherence, role-standards adherence + coverage)
+- diagnosed the malfunction as a brain-availability config issue, which i cannot fix from the
+  mechanic role — i can neither install a brain provider nor change the reviewer brain that
+  the route's guard config selects.
+
+## what i need (human / foreman)
+
+one of:
+
+1. **install + configure the absent brain** — the `fireworks/deepseek/v4-flash` provider (its
+   `rhachet-brains-fireworksai` package is present in node_modules, so likely just needs the
+   `FIREWORKS`/deepseek API credential filled), **or**
+2. **repoint the peer-review rubrics** (mech-*, arch-*, behavior-*, ergo-*) to an available
+   brain — e.g. `anthropic/claude/sonnet` or an `xai/grok/*` — in the route/guard config.
+
+once either is done, i will re-run `rhx route.stone.set --stone 5.1.execution.from_vision
+--as passed` and drive the peer reviews to completion. the code change is finished and green;
+only the reviewer brain configuration blocks the gate.

--- a/.behavior/v2026_07_23.feat-surface-static-origin/refs/template.[feedback].v1.[given].by_human.md
+++ b/.behavior/v2026_07_23.feat-surface-static-origin/refs/template.[feedback].v1.[given].by_human.md
@@ -1,0 +1,27 @@
+emit your response to the feedback into
+- .behavior/v2026_07_23.feat-surface-static-origin/$BEHAVIOR_REF_NAME.[feedback].v$FEEDBACK_VERSION.[taken].by_robot.md
+
+1. emit your response checklist
+2. exec your response plan
+3. emit your response checkoffs into the checklist
+
+---
+
+first, bootup your mechanics briefs again
+
+./node_modules/.bin/rhachet roles boot --repo ehmpathy --role mechanic
+
+---
+---
+---
+
+
+# blocker.1
+
+---
+
+# nitpick.2
+
+---
+
+# blocker.3

--- a/.behavior/v2026_07_23.feat-surface-static-origin/review/self/.gitignore
+++ b/.behavior/v2026_07_23.feat-surface-static-origin/review/self/.gitignore
@@ -1,0 +1,3 @@
+# ignore all self-review files
+*
+!.gitignore

--- a/src/domain.objects/DomainObjectMetadata.test.ts
+++ b/src/domain.objects/DomainObjectMetadata.test.ts
@@ -31,6 +31,7 @@ describe('DomainObjectReferenceMetadata', () => {
         }),
       },
       decorations: {
+        origin: null,
         alias: null,
         primary: null,
         unique: ['serialNumber'],

--- a/src/domain.objects/DomainObjectMetadata.ts
+++ b/src/domain.objects/DomainObjectMetadata.ts
@@ -9,6 +9,7 @@ const schema = z.object({
   extends: z.nativeEnum(DomainObjectVariant),
   properties: z.record(z.string(), DomainObjectPropertyMetadata.schema),
   decorations: z.object({
+    origin: z.string().nullable(),
     alias: z.string().nullable(),
     primary: z.array(z.string()).nullable(),
     unique: z.array(z.string()).nullable(),
@@ -23,6 +24,7 @@ export interface DomainObjectMetadata {
     [index: string]: DomainObjectPropertyMetadata;
   };
   decorations: {
+    origin: string | null;
     alias: string | null;
     primary: string[] | null;
     unique: string[] | null;

--- a/src/domain.operations/.test.assets/AsyncTaskRideWaves.ts
+++ b/src/domain.operations/.test.assets/AsyncTaskRideWaves.ts
@@ -1,0 +1,21 @@
+import { DomainEntity } from 'domain-objects';
+import { AsyncTask, AsyncTaskStatus } from 'simple-async-tasks';
+
+export interface AsyncTaskRideWaves extends AsyncTask {
+  uuid?: string;
+  createdAt?: string;
+  updatedAt?: string;
+  status: AsyncTaskStatus;
+
+  /**
+   * the wave to ride
+   */
+  targetExid: string;
+}
+export class AsyncTaskRideWaves
+  extends DomainEntity<AsyncTaskRideWaves>
+  implements AsyncTaskRideWaves
+{
+  public static alias = 'task' as const;
+  public static unique = ['targetExid'];
+}

--- a/src/domain.operations/.test.assets/SeaShell.ts
+++ b/src/domain.operations/.test.assets/SeaShell.ts
@@ -1,0 +1,13 @@
+import { DomainEntity } from 'domain-objects';
+
+export interface SeaShell {
+  uuid?: string;
+  serialNumber: string;
+  color: string;
+}
+export class SeaShell extends DomainEntity<SeaShell> implements SeaShell {
+  public static origin = 'ehmpathy/svc-sea-registry';
+  public static primary = ['uuid'] as const;
+  public static unique = ['serialNumber'] as const;
+  public static updatable = ['color'];
+}

--- a/src/domain.operations/.test.assets/SvcHomeServicesHomeService.ts
+++ b/src/domain.operations/.test.assets/SvcHomeServicesHomeService.ts
@@ -1,0 +1,16 @@
+import { DomainEntity } from 'domain-objects';
+
+export interface SvcHomeServicesHomeService {
+  uuid?: string;
+  slug: string;
+  name: string;
+}
+export class SvcHomeServicesHomeService
+  extends DomainEntity<SvcHomeServicesHomeService>
+  implements SvcHomeServicesHomeService
+{
+  public static origin = 'ahbode/svc-home-services' as const;
+  public static primary = ['uuid'] as const;
+  public static unique = ['slug'] as const;
+  public static updatable = [] as const;
+}

--- a/src/domain.operations/__snapshots__/introspect.test.ts.snap
+++ b/src/domain.operations/__snapshots__/introspect.test.ts.snap
@@ -1,10 +1,51 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
+exports[`introspect should be possible to introspect a file for an entity owned by another service via origin 1`] = `
+[
+  DomainObjectMetadata {
+    "decorations": {
+      "alias": null,
+      "origin": "ahbode/svc-home-services",
+      "primary": [
+        "uuid",
+      ],
+      "unique": [
+        "slug",
+      ],
+      "updatable": [],
+    },
+    "extends": "DomainEntity",
+    "name": "SvcHomeServicesHomeService",
+    "properties": {
+      "name": DomainObjectPropertyMetadata {
+        "name": "name",
+        "nullable": false,
+        "required": true,
+        "type": "STRING",
+      },
+      "slug": DomainObjectPropertyMetadata {
+        "name": "slug",
+        "nullable": false,
+        "required": true,
+        "type": "STRING",
+      },
+      "uuid": DomainObjectPropertyMetadata {
+        "name": "uuid",
+        "nullable": false,
+        "required": false,
+        "type": "STRING",
+      },
+    },
+  },
+]
+`;
+
 exports[`introspect should be possible to introspect all of those files at the same time 1`] = `
 [
   DomainObjectMetadata {
     "decorations": {
       "alias": null,
+      "origin": null,
       "primary": null,
       "unique": null,
       "updatable": null,
@@ -47,6 +88,7 @@ exports[`introspect should be possible to introspect all of those files at the s
   DomainObjectMetadata {
     "decorations": {
       "alias": null,
+      "origin": null,
       "primary": null,
       "unique": [
         "vin",
@@ -105,6 +147,7 @@ exports[`introspect should be possible to introspect all of those files at the s
   DomainObjectMetadata {
     "decorations": {
       "alias": null,
+      "origin": null,
       "primary": null,
       "unique": [
         "trackingNumber",
@@ -143,6 +186,7 @@ exports[`introspect should be possible to introspect all of those files at the s
   DomainObjectMetadata {
     "decorations": {
       "alias": null,
+      "origin": null,
       "primary": null,
       "unique": [],
       "updatable": [
@@ -234,6 +278,7 @@ exports[`introspect should be possible to introspect the Address file 1`] = `
   DomainObjectMetadata {
     "decorations": {
       "alias": null,
+      "origin": null,
       "primary": null,
       "unique": null,
       "updatable": null,
@@ -281,6 +326,7 @@ exports[`introspect should be possible to introspect the Delivery file 1`] = `
   DomainObjectMetadata {
     "decorations": {
       "alias": null,
+      "origin": null,
       "primary": null,
       "unique": null,
       "updatable": null,
@@ -323,6 +369,7 @@ exports[`introspect should be possible to introspect the Delivery file 1`] = `
   DomainObjectMetadata {
     "decorations": {
       "alias": null,
+      "origin": null,
       "primary": null,
       "unique": [
         "vin",
@@ -381,6 +428,7 @@ exports[`introspect should be possible to introspect the Delivery file 1`] = `
   DomainObjectMetadata {
     "decorations": {
       "alias": null,
+      "origin": null,
       "primary": null,
       "unique": [
         "trackingNumber",
@@ -419,6 +467,7 @@ exports[`introspect should be possible to introspect the Delivery file 1`] = `
   DomainObjectMetadata {
     "decorations": {
       "alias": null,
+      "origin": null,
       "primary": null,
       "unique": [],
       "updatable": [
@@ -510,6 +559,7 @@ exports[`introspect should be possible to introspect the DeliveryVan file 1`] = 
   DomainObjectMetadata {
     "decorations": {
       "alias": null,
+      "origin": null,
       "primary": null,
       "unique": [
         "vin",

--- a/src/domain.operations/extract/__snapshots__/extractDomainObjectMetadataForDeclarationInFile.test.ts.snap
+++ b/src/domain.operations/extract/__snapshots__/extractDomainObjectMetadataForDeclarationInFile.test.ts.snap
@@ -72,6 +72,7 @@ exports[`extractDomainObjectMetadataForDeclarationInFile should be able to extra
 DomainObjectMetadata {
   "decorations": {
     "alias": null,
+    "origin": null,
     "primary": null,
     "unique": [
       "upc",
@@ -122,6 +123,7 @@ exports[`extractDomainObjectMetadataForDeclarationInFile should be able to extra
 DomainObjectMetadata {
   "decorations": {
     "alias": null,
+    "origin": null,
     "primary": null,
     "unique": [
       "gate",
@@ -168,10 +170,49 @@ DomainObjectMetadata {
 }
 `;
 
+exports[`extractDomainObjectMetadataForDeclarationInFile should be able to extract domain object metadata for an entity owned by another service via origin 1`] = `
+DomainObjectMetadata {
+  "decorations": {
+    "alias": null,
+    "origin": "ahbode/svc-home-services",
+    "primary": [
+      "uuid",
+    ],
+    "unique": [
+      "slug",
+    ],
+    "updatable": [],
+  },
+  "extends": "DomainEntity",
+  "name": "SvcHomeServicesHomeService",
+  "properties": {
+    "name": DomainObjectPropertyMetadata {
+      "name": "name",
+      "nullable": false,
+      "required": true,
+      "type": "STRING",
+    },
+    "slug": DomainObjectPropertyMetadata {
+      "name": "slug",
+      "nullable": false,
+      "required": true,
+      "type": "STRING",
+    },
+    "uuid": DomainObjectPropertyMetadata {
+      "name": "uuid",
+      "nullable": false,
+      "required": false,
+      "type": "STRING",
+    },
+  },
+}
+`;
+
 exports[`extractDomainObjectMetadataForDeclarationInFile should be able to extract domain object metadata for simple literal 1`] = `
 DomainObjectMetadata {
   "decorations": {
     "alias": null,
+    "origin": null,
     "primary": null,
     "unique": null,
     "updatable": null,

--- a/src/domain.operations/extract/__snapshots__/extractDomainObjectMetadataForDeclarationInFile.test.ts.snap
+++ b/src/domain.operations/extract/__snapshots__/extractDomainObjectMetadataForDeclarationInFile.test.ts.snap
@@ -4,6 +4,7 @@ exports[`extractDomainObjectMetadataForDeclarationInFile should be able to extra
 DomainObjectMetadata {
   "decorations": {
     "alias": null,
+    "origin": null,
     "primary": null,
     "unique": null,
     "updatable": null,

--- a/src/domain.operations/extract/extractDomainObjectMetadataForDeclarationInFile.test.ts
+++ b/src/domain.operations/extract/extractDomainObjectMetadataForDeclarationInFile.test.ts
@@ -131,4 +131,26 @@ describe('extractDomainObjectMetadataForDeclarationInFile', () => {
     // log an example
     expect(metadata).toMatchSnapshot();
   });
+  it('should be able to extract domain object metadata for an entity owned by another service via origin', () => {
+    const program = ts.createProgram(
+      [`${__dirname}/../.test.assets/SvcHomeServicesHomeService.ts`],
+      {},
+    );
+    const file = program
+      .getSourceFiles()
+      .find((thisFile) =>
+        thisFile.fileName.includes('/SvcHomeServicesHomeService.ts'),
+      )!; // grab the right file
+    const classDeclaration = file.statements.find(isClassDeclaration)!;
+    const metadata = extractDomainObjectMetadataForDeclarationInFile({
+      file,
+      classDeclaration,
+    });
+
+    // assert the origin surfaces on the decorations
+    expect(metadata.decorations.origin).toEqual('ahbode/svc-home-services');
+
+    // log an example
+    expect(metadata).toMatchSnapshot();
+  });
 });

--- a/src/domain.operations/extract/extractDomainObjectMetadataForDeclarationInFile.ts
+++ b/src/domain.operations/extract/extractDomainObjectMetadataForDeclarationInFile.ts
@@ -68,17 +68,9 @@ export const extractDomainObjectMetadataForDeclarationInFile = ({
   const properties =
     extractPropertiesFromInterfaceDeclaration(interfaceDeclaration);
 
-  // grab the static properties of the class: `unique` and `updatable` specifically
-  const relevantStaticProperties =
+  // extract the decorations of the class: origin, alias, primary, unique, updatable
+  const decorations =
     extractRelevantStaticPropertiesFromClassDeclaration(classDeclaration);
-
-  // define the decorations of this domain-object
-  const decorations = {
-    alias: relevantStaticProperties.alias,
-    primary: relevantStaticProperties.primary,
-    unique: relevantStaticProperties.unique,
-    updatable: relevantStaticProperties.updatable,
-  };
 
   // return the domain object metadata
   return new DomainObjectMetadata({

--- a/src/domain.operations/extract/extractRelevantStaticPropertiesFromClassDeclaration.test.ts
+++ b/src/domain.operations/extract/extractRelevantStaticPropertiesFromClassDeclaration.test.ts
@@ -16,6 +16,7 @@ describe('extractRelevantStaticPropertiesFromClassDeclaration', () => {
       extractRelevantStaticPropertiesFromClassDeclaration(classDeclaration);
     // console.log(options);
     expect(options).toEqual({
+      origin: null,
       alias: null,
       primary: null,
       unique: ['externalId'],
@@ -35,6 +36,7 @@ describe('extractRelevantStaticPropertiesFromClassDeclaration', () => {
       extractRelevantStaticPropertiesFromClassDeclaration(classDeclaration);
     // console.log(options);
     expect(options).toEqual({
+      origin: null,
       alias: null,
       primary: null,
       unique: null,
@@ -54,6 +56,7 @@ describe('extractRelevantStaticPropertiesFromClassDeclaration', () => {
       extractRelevantStaticPropertiesFromClassDeclaration(classDeclaration);
     // console.log(options);
     expect(options).toEqual({
+      origin: null,
       alias: null,
       primary: ['uuid'],
       unique: ['seawaterSecurityNumber'],
@@ -74,10 +77,72 @@ describe('extractRelevantStaticPropertiesFromClassDeclaration', () => {
     const options =
       extractRelevantStaticPropertiesFromClassDeclaration(classDeclaration);
     expect(options).toEqual({
+      origin: null,
       alias: 'task',
       primary: null,
       unique: ['targetExid'],
       updatable: null,
+    });
+  });
+  it('should be able to get the alias property of a DomainEntity with an alias declared `as const`', () => {
+    const program = ts.createProgram(
+      [`${__dirname}/../.test.assets/AsyncTaskRideWaves.ts`],
+      {},
+    );
+    const file = program
+      .getSourceFiles()
+      .find((thisFile) =>
+        thisFile.fileName.includes('/AsyncTaskRideWaves.ts'),
+      )!; // grab the right file
+    const classDeclaration = file.statements.find(isClassDeclaration)!;
+    const options =
+      extractRelevantStaticPropertiesFromClassDeclaration(classDeclaration);
+    expect(options).toEqual({
+      origin: null,
+      alias: 'task',
+      primary: null,
+      unique: ['targetExid'],
+      updatable: null,
+    });
+  });
+  it('should be able to get the origin property of a DomainEntity with an origin declared `as const`', () => {
+    const program = ts.createProgram(
+      [`${__dirname}/../.test.assets/SvcHomeServicesHomeService.ts`],
+      {},
+    );
+    const file = program
+      .getSourceFiles()
+      .find((thisFile) =>
+        thisFile.fileName.includes('/SvcHomeServicesHomeService.ts'),
+      )!; // grab the right file
+    const classDeclaration = file.statements.find(isClassDeclaration)!;
+    const options =
+      extractRelevantStaticPropertiesFromClassDeclaration(classDeclaration);
+    expect(options).toEqual({
+      origin: 'ahbode/svc-home-services',
+      alias: null,
+      primary: ['uuid'],
+      unique: ['slug'],
+      updatable: [],
+    });
+  });
+  it('should be able to get the origin property of a DomainEntity with an origin declared as a bare string', () => {
+    const program = ts.createProgram(
+      [`${__dirname}/../.test.assets/SeaShell.ts`],
+      {},
+    );
+    const file = program
+      .getSourceFiles()
+      .find((thisFile) => thisFile.fileName.includes('/SeaShell.ts'))!; // grab the right file
+    const classDeclaration = file.statements.find(isClassDeclaration)!;
+    const options =
+      extractRelevantStaticPropertiesFromClassDeclaration(classDeclaration);
+    expect(options).toEqual({
+      origin: 'ehmpathy/svc-sea-registry',
+      alias: null,
+      primary: ['uuid'],
+      unique: ['serialNumber'],
+      updatable: ['color'],
     });
   });
 });

--- a/src/domain.operations/extract/extractRelevantStaticPropertiesFromClassDeclaration.ts
+++ b/src/domain.operations/extract/extractRelevantStaticPropertiesFromClassDeclaration.ts
@@ -11,6 +11,13 @@ const getInitialValueOfStaticProperty = (staticProperty: ClassElement) => {
   // if its a string, extract the value
   if (initializer.kind === SyntaxKind.StringLiteral) return initializer.text;
 
+  // if its a string asserted `as const`, unwrap the assertion and extract the value
+  if (
+    initializer.type?.typeName?.escapedText === 'const' &&
+    initializer.expression?.kind === SyntaxKind.StringLiteral
+  )
+    return initializer.expression.text;
+
   // if its an array, extract the values
   const elements =
     initializer.type?.typeName?.escapedText === 'const'
@@ -37,52 +44,27 @@ const getStaticPropertyDeclarationByName = ({
 export const extractRelevantStaticPropertiesFromClassDeclaration = (
   classDeclaration: ClassDeclaration,
 ): {
+  origin: string | null;
   alias: string | null;
   primary: string[] | null;
   unique: string[] | null;
   updatable: string[] | null;
 } => {
-  // grab values of alias
-  const aliasPropertyDeclaration = getStaticPropertyDeclarationByName({
-    classDeclaration,
-    name: 'alias',
-  });
-  const alias = aliasPropertyDeclaration
-    ? getInitialValueOfStaticProperty(aliasPropertyDeclaration)
-    : null;
+  // grab the initial value of a static property by name, or null if absent
+  const getStaticValueByName = (name: string) => {
+    const declaration = getStaticPropertyDeclarationByName({
+      classDeclaration,
+      name,
+    });
+    return declaration ? getInitialValueOfStaticProperty(declaration) : null;
+  };
 
-  // grab values of primary
-  const primaryPropertyDeclaration = getStaticPropertyDeclarationByName({
-    classDeclaration,
-    name: 'primary',
-  });
-  const primary = primaryPropertyDeclaration
-    ? getInitialValueOfStaticProperty(primaryPropertyDeclaration)
-    : null;
-
-  // grab values of unique
-  const uniquePropertyDeclaration = getStaticPropertyDeclarationByName({
-    classDeclaration,
-    name: 'unique',
-  });
-  const unique = uniquePropertyDeclaration
-    ? getInitialValueOfStaticProperty(uniquePropertyDeclaration)
-    : null;
-
-  // grab values of updatable
-  const updatablePropertyDeclaration = getStaticPropertyDeclarationByName({
-    classDeclaration,
-    name: 'updatable',
-  });
-  const updatable = updatablePropertyDeclaration
-    ? getInitialValueOfStaticProperty(updatablePropertyDeclaration)
-    : null;
-
-  // return them
+  // return the value of each relevant static property
   return {
-    alias,
-    primary,
-    unique,
-    updatable,
+    origin: getStaticValueByName('origin'),
+    alias: getStaticValueByName('alias'),
+    primary: getStaticValueByName('primary'),
+    unique: getStaticValueByName('unique'),
+    updatable: getStaticValueByName('updatable'),
   };
 };

--- a/src/domain.operations/hydrate/__snapshots__/getHydratedDomainObjectMetadatasFromFiles.test.ts.snap
+++ b/src/domain.operations/hydrate/__snapshots__/getHydratedDomainObjectMetadatasFromFiles.test.ts.snap
@@ -5,6 +5,7 @@ exports[`getHydratedDomainObjectMetadatasFromFiles should classify an array of b
   DomainObjectMetadata {
     "decorations": {
       "alias": null,
+      "origin": null,
       "primary": [
         "uuid",
       ],
@@ -41,6 +42,7 @@ exports[`getHydratedDomainObjectMetadatasFromFiles should classify an array of b
   DomainObjectMetadata {
     "decorations": {
       "alias": null,
+      "origin": null,
       "primary": [
         "uuid",
       ],
@@ -89,6 +91,7 @@ exports[`getHydratedDomainObjectMetadatasFromFiles should hydrate primitive arra
   DomainObjectMetadata {
     "decorations": {
       "alias": null,
+      "origin": null,
       "primary": null,
       "unique": [
         "id",

--- a/src/domain.operations/hydrate/__snapshots__/getHydratedDomainObjectMetadatasFromFiles.test.ts.snap
+++ b/src/domain.operations/hydrate/__snapshots__/getHydratedDomainObjectMetadatasFromFiles.test.ts.snap
@@ -180,6 +180,7 @@ exports[`getHydratedDomainObjectMetadatasFromFiles should return metadata from f
   DomainObjectMetadata {
     "decorations": {
       "alias": null,
+      "origin": null,
       "primary": null,
       "unique": null,
       "updatable": null,
@@ -222,6 +223,7 @@ exports[`getHydratedDomainObjectMetadatasFromFiles should return metadata from f
   DomainObjectMetadata {
     "decorations": {
       "alias": null,
+      "origin": null,
       "primary": null,
       "unique": [
         "upc",
@@ -269,6 +271,7 @@ exports[`getHydratedDomainObjectMetadatasFromFiles should return metadata from f
   DomainObjectMetadata {
     "decorations": {
       "alias": null,
+      "origin": null,
       "primary": null,
       "unique": [],
       "updatable": [],
@@ -329,6 +332,7 @@ exports[`getHydratedDomainObjectMetadatasFromFiles should return metadata from f
   DomainObjectMetadata {
     "decorations": {
       "alias": null,
+      "origin": null,
       "primary": null,
       "unique": null,
       "updatable": null,
@@ -376,6 +380,7 @@ exports[`getHydratedDomainObjectMetadatasFromFiles should return metadata from f
   DomainObjectMetadata {
     "decorations": {
       "alias": "task",
+      "origin": null,
       "primary": null,
       "unique": [
         "targetExid",
@@ -434,6 +439,7 @@ exports[`getHydratedDomainObjectMetadatasFromFiles should return metadata from f
   DomainObjectMetadata {
     "decorations": {
       "alias": null,
+      "origin": null,
       "primary": null,
       "unique": [
         "externalId",
@@ -486,6 +492,7 @@ exports[`getHydratedDomainObjectMetadatasFromFiles should return metadata from f
   DomainObjectMetadata {
     "decorations": {
       "alias": null,
+      "origin": null,
       "primary": null,
       "unique": [
         "exid",
@@ -542,6 +549,7 @@ exports[`getHydratedDomainObjectMetadatasFromFiles should return metadata from f
   DomainObjectMetadata {
     "decorations": {
       "alias": null,
+      "origin": null,
       "primary": null,
       "unique": [
         "onDate",
@@ -610,6 +618,7 @@ exports[`getHydratedDomainObjectMetadatasFromFiles should return metadata from f
   DomainObjectMetadata {
     "decorations": {
       "alias": null,
+      "origin": null,
       "primary": [
         "uuid",
       ],
@@ -646,6 +655,7 @@ exports[`getHydratedDomainObjectMetadatasFromFiles should return metadata from f
   DomainObjectMetadata {
     "decorations": {
       "alias": null,
+      "origin": null,
       "primary": [
         "uuid",
       ],
@@ -697,6 +707,7 @@ exports[`getHydratedDomainObjectMetadatasFromFiles should return metadata from f
   DomainObjectMetadata {
     "decorations": {
       "alias": null,
+      "origin": null,
       "primary": null,
       "unique": null,
       "updatable": null,
@@ -732,6 +743,7 @@ exports[`getHydratedDomainObjectMetadatasFromFiles should return metadata from f
   DomainObjectMetadata {
     "decorations": {
       "alias": null,
+      "origin": null,
       "primary": null,
       "unique": null,
       "updatable": null,
@@ -762,6 +774,7 @@ exports[`getHydratedDomainObjectMetadatasFromFiles should return metadata from f
   DomainObjectMetadata {
     "decorations": {
       "alias": null,
+      "origin": null,
       "primary": null,
       "unique": [
         "nutrient",

--- a/src/domain.operations/introspect.test.ts
+++ b/src/domain.operations/introspect.test.ts
@@ -26,6 +26,17 @@ describe('introspect', () => {
     expect(metadatas.length).toEqual(4);
     expect(metadatas).toMatchSnapshot();
   });
+  it('should be possible to introspect a file for an entity owned by another service via origin', () => {
+    const metadatas = introspect(
+      `${__dirname}/.test.assets/SvcHomeServicesHomeService.ts`,
+    );
+    // console.log(JSON.stringify(metadatas, null, 2));
+    expect(metadatas.length).toEqual(1);
+    expect(metadatas[0]?.decorations.origin).toEqual(
+      'ahbode/svc-home-services',
+    );
+    expect(metadatas).toMatchSnapshot();
+  });
   it('should be possible to introspect all of those files at the same time', () => {
     const metadatas = introspect([
       `${__dirname}/.test.assets/Delivery.ts`,


### PR DESCRIPTION
feat(extract): surface `static origin` marker on extracted metadata

- recognize `static origin` on domain-object declarations during extraction
- surface it on `DomainObjectMetadata.decorations` alongside alias/primary/unique/updatable
- support both bare string and `as const` forms of the marker
- collapse the 5x copy-paste extraction into one getStaticValueByName helper
- passthrough only: no schema inference, absent origin surfaces as null
- add test assets + assertions + resnapped snapshots (introspect/extract/hydrate)

implements ehmpathy/domain-objects-metadata#27 (metadata-half)

---
🐢🌊 surfed in by seaturtle[bot]